### PR TITLE
Feature(masCmd): add sdf_file parameter and update SDF loading logic

### DIFF
--- a/interfaces/lotusim_msgs/msg/MASCmd.msg
+++ b/interfaces/lotusim_msgs/msg/MASCmd.msg
@@ -11,6 +11,11 @@ string sdf_string
 # Lotusim param will be retrieved from sdf_string
 string model_name
 
+# Optional SDF file name inside the model folder.
+# If not specified, the default file `model.sdf` will be used.
+# Only applicable when the model exists in `assets/models`.
+string sdf_file
+
 # Name of vessel in gazebo
 string vessel_name
 

--- a/systems/entity_manager/src/entity_manager.cpp
+++ b/systems/entity_manager/src/entity_manager.cpp
@@ -420,10 +420,16 @@ std::optional<std::tuple<uint16_t, std::string>> EntityManager::addEntity(
 
         if (!msg.sdf_string.empty()) {
             tinyxml2::XMLDocument sdfDoc;
+
+            // Use the provided sdf_file inside the model folder.
+            // If empty, default to "model.sdf".
+            std::string sdf_filename = msg.sdf_file.empty() ? "model.sdf" : msg.sdf_file;
+            m_logger->info("EntityManager::addEntity: using sdf_file='{}' for model='{}'", sdf_filename, msg.model_name);
+
             tinyxml2::XMLError loadResult =
-                sdfDoc.LoadFile((file_path + "/model.sdf").c_str());
+                sdfDoc.LoadFile((file_path + "/" + sdf_filename).c_str());
             if (loadResult != tinyxml2::XML_SUCCESS) {
-                m_logger->error("    file.{}", file_path + "/model.sdf");
+                m_logger->error("    file.{}", file_path + "/" + sdf_filename);
                 return std::nullopt;
             }
 


### PR DESCRIPTION
- Add optional  field to masCmd message to allow selecting a specific SDF file inside the model directory.
- Update EntityManager to use the provided file when specified, otherwise default to model.sdf.