### PR TITLE
Feature(sensors): add radar sensor plugin adapted from ASVSim

### DIFF
--- a/interfaces/lotusim_sensor_msgs/CMakeLists.txt
+++ b/interfaces/lotusim_sensor_msgs/CMakeLists.txt
@@ -13,6 +13,8 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/PressureDepth.msg"
   "msg/Collision.msg"
   "msg/Collisions.msg"
+  "msg/RadarDetection.msg"
+  "msg/RadarScan.msg"
   "srv/ActivateSensor.srv"
   
   DEPENDENCIES 

--- a/interfaces/lotusim_sensor_msgs/msg/RadarDetection.msg
+++ b/interfaces/lotusim_sensor_msgs/msg/RadarDetection.msg
@@ -1,0 +1,3 @@
+float32 range      # metres
+float32 azimuth    # radians  (0 = bow, positive = port)
+float32 intensity  # 0..1

--- a/interfaces/lotusim_sensor_msgs/msg/RadarScan.msg
+++ b/interfaces/lotusim_sensor_msgs/msg/RadarScan.msg
@@ -1,0 +1,2 @@
+std_msgs/Header header
+RadarDetection[] detections

--- a/systems/sensors/lotusim_sensor_plugin/include/lotusim_sensor_plugin/lotusim_sensor_plugin.hpp
+++ b/systems/sensors/lotusim_sensor_plugin/include/lotusim_sensor_plugin/lotusim_sensor_plugin.hpp
@@ -42,6 +42,7 @@
 #include "lotusim_common/logger.hpp"
 #include "lotusim_sensor_base/custom_sensor.hpp"
 #include "lotusim_sensor_msgs/msg/collisions.hpp"
+#include "radar_sensor/radar_sensor.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "sensor_msgs/msg/point_cloud2.hpp"
 #include "subsea_pressure_sensor/subsea_pressure_sensor.hh"

--- a/systems/sensors/lotusim_sensor_plugin/package.xml
+++ b/systems/sensors/lotusim_sensor_plugin/package.xml
@@ -19,6 +19,7 @@
   <depend>subsea_pressure_sensor</depend>
   <depend>ais_sensor</depend>
   <depend>imu_sensor</depend>
+  <depend>radar_sensor</depend>
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/systems/sensors/lotusim_sensor_plugin/src/lotusim_sensor_plugin.cpp
+++ b/systems/sensors/lotusim_sensor_plugin/src/lotusim_sensor_plugin.cpp
@@ -124,7 +124,7 @@ void LotusimSensorPlugin::OnNewLidarFrame(
     const std::string& /*_format*/)
 {
     sensor_msgs::msg::PointCloud2 msg;
-    msg.header = common::generateHeaderMessage(m_current_time);
+    msg.header = lotusim::common::generateHeaderMessage(m_current_time);
     msg.header.frame_id = m_lidar_name[_entity];  // or proper TF frame
 
     msg.height = _height;
@@ -296,7 +296,17 @@ bool LotusimSensorPlugin::EachNew(
                 _entity,
                 model_name,
                 sensor_name);
-
+        } else if (type == "radar") {
+            m_logger->info(
+                "LotusimSensorPlugin::Radar: Creating sensor [{}/{}]",
+                model_name,
+                sensor_name);
+            sensor = CreateSensor<RadarSensor>(
+                data,
+                model_entity,
+                _entity,
+                model_name,
+                sensor_name);
         } else {
             return true;
         }

--- a/systems/sensors/radar_sensor/CMakeLists.txt
+++ b/systems/sensors/radar_sensor/CMakeLists.txt
@@ -1,0 +1,138 @@
+cmake_minimum_required(VERSION 3.22.1 FATAL_ERROR)
+project(radar_sensor VERSION 0.0.1 LANGUAGES CXX)
+
+#============================================================================
+# Configure the project
+#============================================================================
+include(GNUInstallDirs)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Werror=format-security -Wpedantic)
+endif()
+
+if(LOTUS_TIDY)
+  set(CMAKE_CXX_CLANG_TIDY "clang-tidy;-checks=-*,-header-filter=.*, clang-analyzer-*,modernize-*,performance-*,hicpp-*,concurrency-*,bugprone-*,portability-*,cppcoreguidelines-*")
+endif()
+
+#============================================================================
+# Set project-specific options
+#============================================================================
+if(DEBUG)
+  message("Building ${PROJECT_NAME} with debug options ${DEBUG}")
+  add_compile_options(-g -Og)
+  find_package(backward_ros)
+  add_definitions(-DDEBUG=${DEBUG})
+endif()
+
+if(BUILD_PROFILING)
+  add_compile_options(-pg -g -Og)
+endif()
+
+if(NOT DEFINED BUILD_SHARED_LIBS)
+  option(BUILD_SHARED_LIBS "Build dynamically-linked binaries" ON)
+endif()
+
+#============================================================================
+# Search for dependencies
+#============================================================================
+# ROS 2 packages
+find_package(ament_cmake REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(lotusim_common REQUIRED)
+find_package(lotusim_sensor_base REQUIRED)
+find_package(lotusim_msgs REQUIRED)
+find_package(lotusim_sensor_msgs REQUIRED)
+find_package(sensor_msgs REQUIRED)
+find_package(Eigen3 REQUIRED)
+
+# Gazebo packages — exact same pattern as entity_manager
+find_package(gz-cmake3 REQUIRED)
+set(GZ_CMAKE_VER ${gz-cmake3_VERSION_MAJOR})
+
+find_package(gz-sim8 REQUIRED)
+set(GZ_SIM_VER ${gz-sim8_VERSION_MAJOR})
+
+find_package(gz-msgs10 REQUIRED)
+set(GZ_MSGS_VER ${gz-msgs10_VERSION_MAJOR})
+
+find_package(gz-transport13 REQUIRED)
+set(GZ_TRANSPORT_VER ${gz-transport13_VERSION_MAJOR})
+
+gz_find_package(gz-plugin2 REQUIRED COMPONENTS loader register)
+set(GZ_PLUGIN_VER ${gz-plugin2_VERSION_MAJOR})
+
+#============================================================================
+# Create library
+#============================================================================
+add_library(radar_sensor
+  SHARED
+  src/radar_sensor.cpp
+)
+
+target_include_directories(radar_sensor
+  PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
+  ${EIGEN3_INCLUDE_DIRS}
+)
+
+# target_link_libraries BEFORE ament_target_dependencies — same as entity_manager
+target_link_libraries(radar_sensor
+  PUBLIC
+  gz-sim${GZ_SIM_VER}::gz-sim${GZ_SIM_VER}
+  gz-msgs${GZ_MSGS_VER}::gz-msgs${GZ_MSGS_VER}
+  gz-transport${GZ_TRANSPORT_VER}::gz-transport${GZ_TRANSPORT_VER}
+  gz-plugin${GZ_PLUGIN_VER}::gz-plugin${GZ_PLUGIN_VER}
+)
+
+ament_target_dependencies(radar_sensor
+  PUBLIC
+  rclcpp
+  lotusim_common
+  lotusim_sensor_base
+  lotusim_msgs
+  lotusim_sensor_msgs
+  sensor_msgs
+)
+
+#============================================================================
+# Install
+#============================================================================
+install(
+  TARGETS radar_sensor
+  EXPORT  export_radar_sensor
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+)
+
+install(
+  DIRECTORY include/
+  DESTINATION include
+  FILES_MATCHING
+  PATTERN "*.hpp"
+  PATTERN "*.h"
+  PATTERN ".~" EXCLUDE
+)
+
+#============================================================================
+# Export
+#============================================================================
+ament_export_targets(export_radar_sensor HAS_LIBRARY_TARGET)
+ament_export_dependencies(
+  rclcpp
+  lotusim_common
+  lotusim_sensor_base
+  lotusim_msgs
+  lotusim_sensor_msgs
+  sensor_msgs
+  gz-sim8
+  gz-msgs10
+  gz-transport13
+  gz-plugin2
+)
+ament_export_include_directories(include)
+ament_package()
+gz_create_packages()

--- a/systems/sensors/radar_sensor/include/radar_sensor/radar_sensor.hpp
+++ b/systems/sensors/radar_sensor/include/radar_sensor/radar_sensor.hpp
@@ -1,0 +1,178 @@
+/*
+ * Copyright (c) 2025 Naval Group
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+#pragma once
+
+#include <gz/msgs/pointcloud_packed.pb.h>
+
+#include <array>
+#include <gz/transport/Node.hh>
+#include <mutex>
+#include <rclcpp/rclcpp.hpp>
+#include <sensor_msgs/msg/image.hpp>
+#include <string>
+#include <vector>
+
+#include "lotusim_common/common.hpp"
+#include "lotusim_sensor_base/custom_sensor.hpp"
+#include "lotusim_sensor_msgs/msg/radar_detection.hpp"
+#include "lotusim_sensor_msgs/msg/radar_scan.hpp"
+
+namespace lotusim::sensor {
+
+/**
+ * @brief PSF tuning parameters, loaded from SDF at sensor creation.
+ *
+ */
+struct RadarPSFParams {
+    double ellipse_width{
+        15000.0};  ///< Along-range ellipse divisor — higher = smaller smear
+    double ellipse_height{
+        5000.0};  ///< Cross-range ellipse divisor — higher = smaller smear
+    double range_factor{0.2};  ///< Linear range/size dependency: farther
+                               ///< targets → bigger ellipse
+    int grid_size{
+        900};  ///< Image resolution in pixels (NxN). Python default: 900
+};
+
+/**
+ * @brief Radar sensor plugin for LOTUSim.
+ *
+ * Converts the raw Gazebo GPU-LiDAR PointCloudPacked into two radar-like
+ * images by applying a Point-Spread-Function (PSF) smearing model.
+ *
+ * Data flow
+ * ─────────
+ *  GPU-LiDAR (Gazebo)
+ *      │  gz::msgs::PointCloudPacked  (scan/points topic)
+ *      ▼
+ *  OnPointCloud()  ──cached under mutex──►  m_latest_cloud
+ *      │
+ *  UpdateSensor() [called every PostUpdate tick at update_rate Hz]
+ *      │
+ *  SimulatePSF()  ──►  radar PSF image  +  raw lidar hit image
+ *      │
+ *  PublishImage() ──►  ROS 2 sensor_msgs/Image  ×2
+ *                 ──►  ROS 2 lotusim_sensor_msgs/RadarScan (range/azimuth)
+ *
+ * Integration
+ * ───────────
+ *  LotusimSensorPlugin recognises gz:type="radar" and calls
+ *  CreateSensor<RadarSensor>(...). No extra parameters are needed — the gz
+ *  topic is constructed automatically from the world name (read from ECM on
+ *  the first UpdateSensor tick) and the vessel name.
+ *
+ * Published ROS 2 topics (prefix: <vessel_name>/<sensor_name>)
+ * ─────────────────────────────────────────────────────────────
+ *  /radar/image        sensor_msgs/Image  — PSF-smeared radar display (bgr8)
+ *  /radar/lidar_image  sensor_msgs/Image  — raw lidar hit map (bgr8)
+ *  /radar/detections   lotusim_sensor_msgs/RadarScan — (range, azimuth,
+ * intensity)
+ */
+
+class RadarSensor : public CustomSensor {
+public:
+    RadarSensor(
+        std::shared_ptr<spdlog::logger> logger,
+        rclcpp::Node::SharedPtr node,
+        const gz::sim::Entity& vessel_entity,
+        const gz::sim::Entity& sensor_entity,
+        const std::string& parent_name,
+        const std::string& sensor_name);
+
+    ~RadarSensor() override = default;
+
+    /**
+     * @brief Load PSF parameters from SDF and create ROS 2 publishers.
+     */
+    bool CustomSensorLoad(const sdf::Sensor& _sdf) override;
+
+    /**
+     * @brief Called every PostUpdate tick by LotusimSensorPlugin.
+     *
+     * On the very first call, subscribes to the GPU-LiDAR gz topic.
+     * Subsequent calls process the slatest cached PointCloudPacked and publish
+     * radar images.
+     */
+    virtual bool UpdateSensor(
+        const gz::sim::UpdateInfo& _info,
+        const gz::sim::EntityComponentManager& _ecm) override;
+
+private:
+    /**
+     * @brief Gazebo transport callback — caches the latest PointCloudPacked.
+     *
+     * Called from a gz transport thread. Access to m_latest_cloud is
+     * protected by m_cloud_mutex.
+     */
+    void OnPointCloud(const gz::msgs::PointCloudPacked& _msg);
+
+    /**
+     * @brief PSFResult struct to hold the results of PSF simulation.
+     *
+     * For each (x,y) point:
+     *   1. Normalise world coordinates onto a grid_size × grid_size grid.
+     *   2. Compute direction from radar origin (grid centre) to the point.
+     *   3. Draw a filled rotated ellipse whose semi-axes grow with distance
+     *      (range_factor). This replaces cv2.ellipse() from the Python code.
+     *   4. Mark a single pixel on the lidar image (replaces cv2.circle r=1).
+     * Finally, draw a green dot at the radar origin on both images.
+     *
+     * @param points  Nx2 array of (x, y) in sensor frame (metres)
+     * @return radar BGR image and lidar BGR image (grid_size x grid_size x 3)
+     */
+    struct PSFResult {
+        std::vector<uint8_t> radar_bgr;
+        std::vector<uint8_t> lidar_bgr;
+        int width{0};
+        int height{0};
+    };
+    PSFResult SimulatePSF(
+        const std::vector<std::array<float, 2>>& points) const;
+
+    /**
+     * @brief Pack a BGR byte array into a sensor_msgs::msg::Image and publish.
+     */
+    void PublishImage(
+        rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr& pub,
+        const std::vector<uint8_t>& bgr_data,
+        int width,
+        int height,
+        const std_msgs::msg::Header& header);
+
+    // ── gz transport ─────────────────────────────────────────────────────
+    gz::transport::Node m_gz_node;
+
+    /**
+     * @brief Guards the one-time gz topic subscription.
+     */
+    bool m_subscribed{false};
+
+    // ── Latest cloud (protected by mutex) ──────────────────────────────────
+    std::mutex m_cloud_mutex;
+    gz::msgs::PointCloudPacked m_latest_cloud;
+    bool m_cloud_received{false};
+
+    // ── PSF params ────────────────────────────────────────────────────────
+    RadarPSFParams m_psf;
+
+    // ── ROS 2 publishers ─────────────────────────────────────────────────
+
+    /// PSF-smeared radar display image → <vessel>/<sensor>/radar/image
+    rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr m_radar_img_pub;
+
+    /// Raw lidar hit image → <vessel>/<sensor>/radar/lidar_image
+    rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr m_lidar_img_pub;
+
+    /// Structured polar detections → <vessel>/<sensor>/radar/detections
+    rclcpp::Publisher<lotusim_sensor_msgs::msg::RadarScan>::SharedPtr
+        m_radar_scan_pub;
+};
+
+}  // namespace lotusim::sensor

--- a/systems/sensors/radar_sensor/package.xml
+++ b/systems/sensors/radar_sensor/package.xml
@@ -1,0 +1,21 @@
+<?xml version='1.0' encoding='utf-8'?>
+<package format="3">
+  <name>radar_sensor</name>
+  <version>0.0.1</version>
+  <description>Radar system to pub radar msg in the simulation</description>
+
+  <maintainer email="jgrosset10@gmail.com">juliette</maintainer>
+
+  <author email="jgrosset10@gmail.com">juliette</author>
+
+  <license>EPL-2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <depend>lotusim_sensor_base</depend>
+  <depend>lotusim_sensor_msgs</depend>
+  <depend>lotusim_common</depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/systems/sensors/radar_sensor/src/radar_sensor.cpp
+++ b/systems/sensors/radar_sensor/src/radar_sensor.cpp
@@ -1,0 +1,383 @@
+/*
+ * Copyright (c) 2025 Naval Group
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+#include "radar_sensor/radar_sensor.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <cstring>
+
+#include "lotusim_sensor_base/common.hpp"
+
+namespace lotusim::sensor {
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Constructor
+// ═══════════════════════════════════════════════════════════════════════════
+RadarSensor::RadarSensor(
+    std::shared_ptr<spdlog::logger> logger,
+    rclcpp::Node::SharedPtr node,
+    const gz::sim::Entity& vessel_entity,
+    const gz::sim::Entity& sensor_entity,
+    const std::string& parent_name,
+    const std::string& sensor_name)
+    : CustomSensor(
+          logger,
+          node,
+          vessel_entity,
+          sensor_entity,
+          parent_name,
+          sensor_name)
+{
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// CustomSensorLoad
+// ═══════════════════════════════════════════════════════════════════════════
+bool RadarSensor::CustomSensorLoad(const sdf::Sensor& _sdf)
+{
+    sdf::ElementPtr elem = _sdf.Element();
+
+    GetSDFParam<double>(
+        elem,
+        "psf_ellipse_width",
+        m_psf.ellipse_width,
+        15000.0);
+    GetSDFParam<double>(
+        elem,
+        "psf_ellipse_height",
+        m_psf.ellipse_height,
+        5000.0);
+    GetSDFParam<double>(elem, "psf_range_factor", m_psf.range_factor, 0.2);
+    GetSDFParam<int>(elem, "psf_grid_size", m_psf.grid_size, 900);
+
+    const std::string base = m_vessel_name + "/" + m_sensor_name;
+
+    // Radar topics
+    m_radar_img_pub = m_ros_node->create_publisher<sensor_msgs::msg::Image>(
+        base + "/radar/image",
+        rclcpp::QoS(10));
+    m_lidar_img_pub = m_ros_node->create_publisher<sensor_msgs::msg::Image>(
+        base + "/radar/lidar_image",
+        rclcpp::QoS(10));
+
+    // Structured detections (bonus — not in Python but useful)
+    m_radar_scan_pub =
+        m_ros_node->create_publisher<lotusim_sensor_msgs::msg::RadarScan>(
+            base + "/radar/detections",
+            rclcpp::QoS(10));
+
+    m_logger->info(
+        "RadarSensor [{}]: publishers ready on [{}]",
+        m_sensor_name,
+        base);
+    return true;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// OnPointCloud
+// ═══════════════════════════════════════════════════════════════════════════
+void RadarSensor::OnPointCloud(const gz::msgs::PointCloudPacked& _msg)
+{
+    std::lock_guard<std::mutex> lock(m_cloud_mutex);
+    m_latest_cloud = _msg;
+    m_cloud_received = true;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// UpdateSensor
+//  if (first time)  →  subscribe to gz topic lidar_sensor using world name from
+//  ECM if (!EnableMeasurement)  →  return false process + publishs
+// ═══════════════════════════════════════════════════════════════════════════
+bool RadarSensor::UpdateSensor(
+    const gz::sim::UpdateInfo& _info,
+    const gz::sim::EntityComponentManager& _ecm)
+{
+    // ── One-time setup: subscribe using world name from ECM ───────────────s
+    if (!m_subscribed) {
+        std::string world_name = lotusim::common::getWorldName(_ecm);
+        std::string topic = "world/" + world_name + "/model/" + m_vessel_name +
+                            "/link/base_link/sensor/lidar_sensor/scan/points";
+
+        if (!m_gz_node.Subscribe(topic, &RadarSensor::OnPointCloud, this)) {
+            m_logger->error(
+                "RadarSensor::UpdateSensor: failed to subscribe to [{}]",
+                topic);
+            return false;
+        }
+        m_logger->info("RadarSensor::UpdateSensor: subscribed to [{}]", topic);
+        m_subscribed = true;
+    }
+    // m_logger->info(
+    //     "RadarSensor::UpdateSensor: tick simTime={} m_is_on={} m_cloud_received={}",
+    //     _info.simTime.count(),
+    //     m_is_on,
+    //     m_cloud_received);
+
+    // ── EnableMeasurement ───────────────────────────────────────────
+    if (!EnableMeasurement(_info.simTime))
+        return false;
+
+    // ── Grab latest cloud ─────────────────────────────────────────────────
+    gz::msgs::PointCloudPacked cloud_copy;
+    {
+        std::lock_guard<std::mutex> lock(m_cloud_mutex);
+        if (!m_cloud_received)
+            return true;
+        cloud_copy = m_latest_cloud;
+        m_cloud_received = false;
+    }
+
+    // ── Decode x, y from PointCloudPacked ────────────────────────────────
+    int x_offset = -1, y_offset = -1;
+    const uint32_t point_step = cloud_copy.point_step();
+
+    for (int i = 0; i < cloud_copy.field_size(); ++i) {
+        const auto& f = cloud_copy.field(i);
+        if (f.name() == "x")
+            x_offset = static_cast<int>(f.offset());
+        if (f.name() == "y")
+            y_offset = static_cast<int>(f.offset());
+    }
+    m_logger->info(
+        "point_step={} total_bytes={} n_points={}",
+        point_step,
+        cloud_copy.data().size(),
+        cloud_copy.data().size() / point_step);
+
+    if (x_offset < 0 || y_offset < 0) {
+        m_logger->warn(
+            "RadarSensor [{}]: cloud missing x/y fields",
+            m_sensor_name);
+        return true;
+    }
+
+    const auto& raw = cloud_copy.data();
+    const std::size_t n = raw.size() / point_step;
+
+    std::vector<std::array<float, 2>> points;
+    points.reserve(n);
+
+    if (n > 0) {
+        const auto* ptr = reinterpret_cast<const uint8_t*>(raw.data());
+        float x, y;
+        std::memcpy(&x, ptr + x_offset, sizeof(float));
+        std::memcpy(&y, ptr + y_offset, sizeof(float));
+        m_logger->info("  first point raw: x={} y={}", x, y);
+    }
+
+    for (std::size_t i = 0; i < n; ++i) {
+        const auto* base_ptr =
+            reinterpret_cast<const uint8_t*>(raw.data()) + i * point_step;
+        float x, y;
+        std::memcpy(&x, base_ptr + x_offset, sizeof(float));
+        std::memcpy(&y, base_ptr + y_offset, sizeof(float));
+        if (!std::isfinite(x) || !std::isfinite(y))
+            continue;
+        points.push_back({x, y});
+    }
+
+    if (points.empty()) {
+        m_logger->warn("RadarSensor [{}]: no valid points", m_sensor_name);
+        return true;
+    }
+
+    // ── Apply PSF ─────────────────────────────────────────────────────────
+    PSFResult result = SimulatePSF(points);
+
+    // ── Build header ──────────────────────────────────────────────────────
+    std_msgs::msg::Header header =
+        lotusim::common::generateHeaderMessage(_info.simTime);
+    header.frame_id = m_vessel_name + "/" + m_sensor_name;
+
+    // ── Publish images  ─────────────────────────────────────────────────────
+    PublishImage(
+        m_radar_img_pub,
+        result.radar_bgr,
+        result.width,
+        result.height,
+        header);
+    PublishImage(
+        m_lidar_img_pub,
+        result.lidar_bgr,
+        result.width,
+        result.height,
+        header);
+
+    // ── Also publish structured RadarScan detections ──────────────────────
+    // Derived from points: convert (x,y) → (range, azimuth, intensity=1)
+    lotusim_sensor_msgs::msg::RadarScan scan_msg;
+    scan_msg.header = header;
+    for (auto& p : points) {
+        lotusim_sensor_msgs::msg::RadarDetection det;
+        det.range = std::sqrt(p[0] * p[0] + p[1] * p[1]);
+        det.azimuth = std::atan2(p[1], p[0]);
+        det.intensity = 1.0f;
+        scan_msg.detections.push_back(det);
+    }
+    m_radar_scan_pub->publish(scan_msg);
+
+    m_last_measurement_time = _info.simTime;
+    return true;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// SimulatePSF
+// ═══════════════════════════════════════════════════════════════════════════
+RadarSensor::PSFResult RadarSensor::SimulatePSF(
+    const std::vector<std::array<float, 2>>& points) const
+{
+    const int G = m_psf.grid_size;
+    const float Gf = static_cast<float>(G);
+
+    PSFResult result;
+    result.width = G;
+    result.height = G;
+
+    std::vector<float> radar_grid(G * G, 0.0f);
+    std::vector<float> lidar_grid(G * G, 0.0f);
+
+    if (points.empty()) {
+        result.radar_bgr.assign(G * G * 3, 0);
+        result.lidar_bgr.assign(G * G * 3, 0);
+        return result;
+    }
+
+    // ── Normalisation  ────────────────────────────────────────────────────
+    float min_x = points[0][0], min_y = points[0][1];
+    float max_x = min_x, max_y = min_y;
+    for (auto& p : points) {
+        min_x = std::min(min_x, p[0]);
+        min_y = std::min(min_y, p[1]);
+        max_x = std::max(max_x, p[0]);
+        max_y = std::max(max_y, p[1]);
+    }
+    const float range_x = std::max(max_x - min_x, 1e-6f);
+    const float range_y = std::max(max_y - min_y, 1e-6f);
+
+    const float radar_raw_x = Gf * 0.5f;  // = 450 for G=900
+    const float radar_raw_y = Gf * 0.5f;
+
+    struct GridPt {
+        float gx, gy;
+    };
+    std::vector<GridPt> gpts;
+    gpts.reserve(points.size());
+    for (auto& p : points) {
+        float gx = std::round(((p[0] - min_x) / range_x) * (Gf - 1.0f)) + 1.0f;
+        float gy = std::round(((p[1] - min_y) / range_y) * (Gf - 1.0f)) + 1.0f;
+        gpts.push_back({gx, gy});
+    }
+
+    const float ef_w = static_cast<float>(m_psf.ellipse_width);
+    const float ef_h = static_cast<float>(m_psf.ellipse_height);
+    const float rf = static_cast<float>(m_psf.range_factor);
+
+    for (std::size_t idx = 0; idx < gpts.size(); ++idx) {
+        const float gx = gpts[idx].gx;
+        const float gy = gpts[idx].gy;
+
+        const float dir_x = gx - radar_raw_x;
+        const float dir_y = gy - radar_raw_y;
+
+        const float perp_x = -dir_y;
+        const float perp_y = dir_x;
+
+        const float angle_deg =
+            std::atan2(perp_y, perp_x) * 180.0f / static_cast<float>(M_PI);
+        const float angle_rad = angle_deg * static_cast<float>(M_PI) / 180.0f;
+
+        const float distance = std::sqrt(dir_x * dir_x + dir_y * dir_y);
+
+        const float a = std::max(3.0f, std::round(distance * rf * Gf / ef_w));
+        const float b = std::max(2.0f, std::round(distance * rf * Gf / ef_h));
+
+        const float cos_a = std::cos(angle_rad);
+        const float sin_a = std::sin(angle_rad);
+
+        const int x0 = std::max(0, static_cast<int>(gx - a - b - 1));
+        const int x1 = std::min(G - 1, static_cast<int>(gx + a + b + 1));
+        const int y0 = std::max(0, static_cast<int>(gy - a - b - 1));
+        const int y1 = std::min(G - 1, static_cast<int>(gy + a + b + 1));
+
+        for (int py = y0; py <= y1; ++py)
+            for (int px = x0; px <= x1; ++px) {
+                const float dx = static_cast<float>(px) - gx;
+                const float dy = static_cast<float>(py) - gy;
+                const float u = dx * cos_a + dy * sin_a;
+                const float v = -dx * sin_a + dy * cos_a;
+                if ((u * u) / (b * b) + (v * v) / (a * a) <= 1.0f)
+                    radar_grid[py * G + px] = 1.0f;
+            }
+
+        const int ix = std::clamp(static_cast<int>(gx), 0, G - 1);
+        const int iy = std::clamp(static_cast<int>(gy), 0, G - 1);
+        lidar_grid[iy * G + ix] = 1.0f;
+    }
+
+    // Green dot at radar origin
+    const int dot_x = std::clamp(static_cast<int>(radar_raw_x), 0, G - 1);
+    const int dot_y = std::clamp(static_cast<int>(radar_raw_y), 0, G - 1);
+    for (int dy = -5; dy <= 5; ++dy)
+        for (int dx = -5; dx <= 5; ++dx) {
+            if (dx * dx + dy * dy <= 25) {
+                int px = std::clamp(dot_x + dx, 0, G - 1);
+                int py = std::clamp(dot_y + dy, 0, G - 1);
+                radar_grid[py * G + px] = 2.0f;
+                lidar_grid[py * G + px] = 2.0f;
+            }
+        }
+
+    // ── Float grid → BGR uint8 ────────────────────────────────────────────
+    result.radar_bgr.resize(G * G * 3);
+    result.lidar_bgr.resize(G * G * 3);
+
+    for (int i = 0; i < G * G; ++i) {
+        auto write = [](std::vector<uint8_t>& buf, int i, float v) {
+            if (v >= 2.0f) {  // green dot
+                buf[i * 3 + 0] = 0;
+                buf[i * 3 + 1] = 255;
+                buf[i * 3 + 2] = 0;
+            } else {
+                uint8_t c = static_cast<uint8_t>(v * 255.0f);
+                buf[i * 3 + 0] = c;  // B
+                buf[i * 3 + 1] = c;  // G
+                buf[i * 3 + 2] = c;  // R
+            }
+        };
+        write(result.radar_bgr, i, radar_grid[i]);
+        write(result.lidar_bgr, i, lidar_grid[i]);
+    }
+
+    return result;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// PublishImage — pack BGR bytes into sensor_msgs::msg::Image
+// ═══════════════════════════════════════════════════════════════════════════
+void RadarSensor::PublishImage(
+    rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr& pub,
+    const std::vector<uint8_t>& bgr_data,
+    int width,
+    int height,
+    const std_msgs::msg::Header& header)
+{
+    sensor_msgs::msg::Image img;
+    img.header = header;
+    img.height = static_cast<uint32_t>(height);
+    img.width = static_cast<uint32_t>(width);
+    img.encoding = "bgr8";
+    img.step = static_cast<uint32_t>(width * 3);
+    img.is_bigendian = false;
+    img.data = bgr_data;
+    pub->publish(img);
+}
+
+}  // namespace lotusim::sensor


### PR DESCRIPTION
Introduce a GPU-LiDAR-based radar simulation plugin for LOTUSim, adapted from ASVSim's radar model.

The plugin converts raw Gazebo GPU-LiDAR PointCloudPacked data into radar-like imagery using a Point-Spread-Function (PSF) smearing model.

New packages:
- systems/sensors/radar_sensor: standalone RadarSensor plugin
- interfaces/lotusim_sensor_msgs: add RadarDetection and RadarScan messages

Changes:
- LotusimSensorPlugin can instantiate RadarSensor via CreateSensor<RadarSensor>()

Published ROS 2 topics (<vessel>/<sensor> prefix):
  /radar/image        — PSF-smeared radar display (bgr8)
  /radar/lidar_image  — raw lidar hit map (bgr8)
  /radar/detections   — RadarScan (range, azimuth, intensity)