### PR TITLE
Fix(physics_engine_interface): correct xdyn quaternion j/k mapping on receive

### DIFF
--- a/systems/physics_engine_interface/src/xdyn_websocket.cpp
+++ b/systems/physics_engine_interface/src/xdyn_websocket.cpp
@@ -268,8 +268,8 @@ void XdynWebsocket::onMessage(
     auto ned_quad = gz::math::Quaterniond(
         reply["qr"].back().get<double>(),
         reply["qi"].back().get<double>(),
-        reply["qk"].back().get<double>(),
-        reply["qj"].back().get<double>());
+        reply["qj"].back().get<double>(),
+        reply["qk"].back().get<double>());
 
     auto gz_position = vecNedToEnu(ned_position);
     auto gz_quad = quatNedToEnu(ned_quad);


### PR DESCRIPTION
Closes #27.

## What

Corrects the xdyn quaternion `j`/`k` mapping on the co-simulation **receive** path in `systems/physics_engine_interface/src/xdyn_websocket.cpp`.

`onMessage` rebuilt the NED quaternion as `Quaterniond(qr, qi, qk, qj)`, reading the `qj`/`qk` reply fields into swapped slots. `gz::math::Quaterniond` is `(w, x, y, z) == (qr, qi, qj, qk)`, and the send path (`getNewState`) already packs them in the standard order — so receive and send were not inverses.

```diff
     auto ned_quad = gz::math::Quaterniond(
         reply["qr"].back().get<double>(),
         reply["qi"].back().get<double>(),
-        reply["qk"].back().get<double>(),
-        reply["qj"].back().get<double>());
+        reply["qj"].back().get<double>(),
+        reply["qk"].back().get<double>());
```

## Symptom

A pure yaw came back as roll/pitch: a steered vessel never accumulated heading and dead-reckoned in a straight line. Invisible at identity; surfaces as soon as a vessel has to turn (e.g. a sailboat rounding a mark).

## Why the fix belongs on the client side

The xdyn JSON co-sim wire format is standard and symmetric (verified on `sirehna/xdyn@master`):

- `core/update_kinematics.cpp`: `_QJ = q.y()`, `_QK = q.z()`
- `observers_and_api/JSONSerializer.cpp`: parse (`find_double("qj", …)`) and serialize (`doc["qj"] ← state.qj`) both by name, exact inverses
- matches the pitch example in the xdyn User Guide (`"qj": [0, 0.0499792]`)

The defect was purely the client's receive slot order. Convention-neutral; no change to the send path; does not affect Unity rendering (the gz↔Unity `Z→-Y` transform is independent, on the Unity side).

## Test

`colcon build --merge-install --packages-select physics_engine_interface` succeeds (verified in the `ghcr.io/naval-group/lotusim` container). End-to-end: with the fix and xdyn unchanged, a steered vessel accumulates heading correctly (a sailboat rounds a race mark).
