### PR TITLE
Docs: add AGENTS.md and a coding-agent onboarding skill

### DIFF
--- a/.agents/skills/lotusim-developer/README.md
+++ b/.agents/skills/lotusim-developer/README.md
@@ -1,0 +1,39 @@
+# Using the lotusim-developer skill
+
+This repo ships a coding-agent skill at `.agents/skills/lotusim-developer/`
+(`SKILL.md` + `references/`). `AGENTS.md` at the repo root is read by every major
+agent with no setup; this skill adds a deeper, task-oriented map (it opens with
+6 field-tested pitfalls).
+
+`SKILL.md` follows the open agent-skill format (name/description frontmatter +
+markdown), so it works with any harness that supports skills.
+
+## Codex
+
+Zero setup — Codex auto-discovers skills under `.agents/skills/` (repo scope).
+
+## Claude Code
+
+Claude Code discovers skills under `.claude/skills/`. Link it once:
+
+```bash
+# this repo only
+mkdir -p .claude/skills
+ln -s ../../.agents/skills/lotusim-developer .claude/skills/lotusim-developer
+# or user-wide (all your repos)
+mkdir -p ~/.claude/skills
+ln -s "$PWD/.agents/skills/lotusim-developer" ~/.claude/skills/lotusim-developer
+```
+
+## Universal installer (optional)
+
+```bash
+npx skills@latest add naval-group/LOTUSim
+```
+
+Fans the skill out to the agents you select. Third-party tool — review before use.
+
+## Other harnesses
+
+They all read `AGENTS.md` at the repo root with no setup. For first-class skill
+support, see your harness's own skills documentation.

--- a/.agents/skills/lotusim-developer/SKILL.md
+++ b/.agents/skills/lotusim-developer/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: lotusim-developer
+description: Build, run, and contribute to LOTUSim (Naval Group's ROS2 + Gazebo + xdyn maritime simulator). Use to install/build LOTUSim, add a vehicle/model, run a simulation with physics, debug a vessel that won't move, or prepare a PR. Essential before any `lotusim`/`gz` command — the architecture (physics = external xdyn co-sim, rendering in Gazebo OR Unity) traps anyone who doesn't know it.
+---
+
+# LOTUSim developer
+
+LOTUSim is Naval Group's open-source (EPL-2.0) multi-agent maritime simulator.
+Stack: **ROS2 + Gazebo** (orchestration/rendering) + **xdyn** (rigid-body
+dynamics, in co-simulation). Repo: `github.com/naval-group/LOTUSim`.
+
+This skill condenses non-obvious, field-verified knowledge. **Read the 6
+pitfalls below first** — each one costs hours if ignored.
+
+## The 6 pitfalls (know these BEFORE coding)
+
+1. **Physics is an EXTERNAL xdyn server, not a Gazebo plugin.** Gazebo's
+   `physics_engine_interface` is a *websocket client* that connects to an
+   `xdyn-for-cs` launched separately (one per vessel, on a TCP port: 12345,
+   12346…). **`lotusim run` launches only `gz` — NOT xdyn.** With no xdyn server
+   listening, a vessel spawns and renders but has **no dynamics**:
+   `XdynWebsocket::onFail` → `loadVessel: Loading failed, Removing physics`.
+   → To run with physics: see `references/run-and-verify.md`.
+
+2. **Many models have NO `<visual>`** (collision only). Ships such as `wamv`,
+   `dtmb_hull`, `lrauv` render in **Unity** (`render_plugin` → ROS2 → Unity
+   client), so in the **Gazebo GUI they are invisible** (toggle *Entity Tree →
+   right-click → View → Collisions* to see them). To display a vessel directly
+   in gz, give it a `<visual>` — a legitimate LOTUSim pattern (cf. `fremm`,
+   `commando`).
+
+3. **Ubuntu 24.04 (noble) → ROS2 Jazzy + Gazebo Harmonic.** Not Humble (= 22.04).
+   Harmonic ⇒ prefix **`gz`** (`gz sim`, `gz.msgs.*`), never `ign`/Fortress. The
+   `launch/lotusim` wrapper auto-detects the codename and sets `ROS_DISTRO`/
+   `GAZEBO_VERSION` on its own. Install: `lotusim install`.
+
+4. **ROS setup scripts are bash-only.** `source /opt/ros/jazzy/setup.bash` breaks
+   under zsh (`complete: command not found`, empty `${BASH_SOURCE}` → wrong
+   paths, and `CMAKE_PREFIX_PATH`/`AMENT_PREFIX_PATH` unset → a build that can't
+   find `geometry_msgs`). Under zsh: source `setup.zsh`, or go through the
+   `lotusim` wrapper (shebang `#!/bin/bash`).
+
+5. **`pkill -f "gz sim"` / `pkill xdyn-for-cs` KILL THEMSELVES.** The pattern
+   matches your own shell's command line (which contains that text) → self-kill
+   (exit ~144). Capture the PIDs (`pid=$!`) and `kill "$pid"`, or use a
+   `trap cleanup EXIT`.
+
+6. **In co-sim, THRUST comes neither from the yaml `commands:` block nor from the
+   `waypoint_follower`.** `xdyn-for-cs` **ignores** the yaml `commands:` block.
+   Thruster setpoints are **published** on the ROS2 topic
+   `/<world>/vessel_cmd_array` (`lotusim_msgs/msg/VesselCmdArray`): each
+   `VesselCmd.cmd_string` is a JSON `{"<thruster>(rpm)": <val>,
+   "<thruster>(P/D)": <val>}` that `physics_interface_plugin` forwards verbatim
+   to xdyn. With no publisher → hardcoded default `<thruster>(rpm)=2.0` →
+   near-zero thrust (warning `Wageningen … n too small`). The `waypoint_follower`
+   emits status only: it is a separate **kinematic** mode, and **no world
+   combines it** with `physics_engine_interface`. → Moving a vessel UNDER PHYSICS
+   = a small rclpy node publishing on `vessel_cmd_array` (cf.
+   `references/run-and-verify.md`). The **reference pattern** lives in
+   **`LOTUSim-generic-scenario`** (`lrauv_propeller.py`), **not in the core** —
+   that's where controllers live (cf. `references/architecture.md`).
+
+## Quick start
+
+```bash
+# Container (reproducible; see AGENTS.md for the mount-and-build pattern)
+docker run --rm -it ghcr.io/naval-group/lotusim:latest bash
+
+# Native install / build (bash only)
+lotusim install            # ROS2 Jazzy + Gazebo Harmonic + colcon build
+lotusim build              # rebuild only; clean_build to start fresh
+
+# Run a world WITH physics (xdyn server(s) + gz) — pitfall #1:
+#   start one xdyn-for-cs per vessel (each on its TCP port), then:
+lotusim run <world>.world           # add --gui for the Gazebo GUI
+
+# Run a world WITHOUT physics (gz only — render / plugin debug)
+lotusim run --gui <world>.world
+```
+
+Physics success = log `PhysicsInterfacePlugin::loadVessel: ... Surface init
+completed` + `XdynWebsocket::onOpen`. Failure = `onFail` / `unable to connect` →
+no xdyn server on the port, or a port/uri that does not match the world.
+
+## Adding a vehicle (the typical contribution)
+
+A model lives in `assets/models/<name>/`: `model.config`, `model.sdf` (SDF 1.10,
+minimal: collision + sensors; add a `<visual>` to see it in gz), `<name>.yaml`
+(the **xdyn model**: inertia, added mass, damping, propulsion — this is where the
+dynamics are), `meshes/` (.dae visual + one .stl for xdyn hydrostatics). The
+vehicle is wired into a world via `<include>` + `<lotus_param>`
+(`physics_engine_interface` → xdyn port + thrusters; `waypoint_follower`;
+`render_interface`). Full templates + protocol: `references/models-and-worlds.md`.
+
+⚠️ **Split:** the **model** (assets) goes in the **core**; its
+**controller/scenario** goes in **`LOTUSim-generic-scenario`** (`src/agents/`),
+**not** the core (cf. `references/architecture.md`).
+
+PR workflow (`CONTRIBUTING.md`): issue (label `new_model`) → announce yourself →
+fork → implement → test → PR referencing the issue. **License EPL-2.0**: never
+vendor GPL assets (e.g. ArduPilot SITL_Models) or assets without redistribution
+rights (e.g. manufacturer CAD); re-author from public dimensions only.
+
+## References (load as needed)
+
+- `references/architecture.md` — where to find what: the wiki index, the
+  **`LOTUSim-generic-scenario`** repo (controllers/scenarios), the Unity repos,
+  the ecosystem map; plus the gz↔xdyn↔Unity data flow and coordinate conventions
+  (NED/ENU/Unity, quaternion `qr,qi,qj,qk` order, `Z→-Y`).
+- `references/models-and-worlds.md` — anatomy of `model.config`/`model.sdf`/
+  `<name>.yaml`, the `<lotus_param>` block, visual-vs-Unity, copy-paste
+  templates, mesh generation.
+- `references/run-and-verify.md` — xdyn co-sim orchestration, `xdyn-for-cs`
+  (args, ports), headless verification, the "did the vessel actually move?" oracle.

--- a/.agents/skills/lotusim-developer/references/architecture.md
+++ b/.agents/skills/lotusim-developer/references/architecture.md
@@ -1,0 +1,127 @@
+# LOTUSim — ecosystem & data flow (where to find what)
+
+The `naval-group/LOTUSim` core is not self-sufficient: the knowledge and the
+runnable pieces are spread across the **wiki** + a **scenario** repo + three
+**Unity** repos. This page is the index, plus the gz ↔ xdyn ↔ Unity data flow
+and the coordinate conventions.
+
+## The wiki (`github.com/naval-group/LOTUSim/wiki`)
+
+Git-cloneable: `git clone https://github.com/naval-group/LOTUSim.wiki.git`.
+The most useful pages:
+
+| Page | Content |
+|---|---|
+| **Xdyn-User-Guide** (the bible) | NED + body frames (X-fwd, Y-stbd, Z-down), rotation convention `Z/Y/X` `[psi, theta', phi'']` (the only one supported), quaternions `qr,qi,qj,qk`, mesh (normals facing the fluid), control surfaces (`hydrodynamic polar`), propellers (Kt/Kq, prop+rudder, Wageningen B), a full yaml example, units (trap: `ton` = 907 kg). |
+| **Core-Development** | the `render_plugin` (SDF), the `<lotus_param>` block (`render_interface`/`physics_engine_interface`), and the gz↔Unity `Z→-Y` frame conversion. |
+| **Physics-Implementation** | xdyn co-sim, Unity↔xdyn wave sync (spatially periodic waves, period = the Unity HDRP tile size). |
+| **Platform_Model_Characteristics** | per-model sheets (dimensions, masses, frame). |
+| **Gazebo-Setup** | `model.config`/`model.sdf`, mesh formats (STL/DAE/OBJ), `<visual>` optional because Unity renders (→ models are invisible in the gz GUI). |
+| **Getting-Started** | overview (3 steps: sdf → physics engine → Unity), light; the real walkthrough is in `LOTUSim-generic-scenario` below. |
+| Unity-Setup / Unity-Development | the `lotusim_interface` scripts (`common.cs` = pose conversion, `LotusimConnector.cs`). |
+| Xdyn-Setup / Xdyn-Development | building xdyn, modules, PR workflow (short feature branch tied to an issue, no direct commit to master, CI mandatory). |
+
+## `naval-group/LOTUSim-generic-scenario` — the runnable walkthrough
+
+The ready-to-use **scenario workspace** on top of the core (covers what the
+wiki's Getting-Started only skims). It contains:
+
+- an **automated installer** `install_core_and_generic_scenario.sh`: detects
+  Ubuntu→ROS (22.04→Humble, 24.04→Jazzy), clones the core into a colcon
+  workspace, configures `.bashrc`, runs `lotusim install`, builds (idempotent).
+- a **config-driven runner** `src/simulation_run/executable/scenario_launch.sh
+  --config <x>.json` (e.g. `defenseScenario.json`); spawns agents (initial-pose
+  formats documented); **thruster control via a ROS topic** (`vessel_cmd_array`, cf. pitfall #6).
+- **architecture docs** `doc/DIAGRAMS.md`: package tree, class/sequence diagrams,
+  the `defenseScenario` launch sequence, nodes/topics/actions.
+- a **prebuilt Linux Unity player** under `lotusim_unity_executables/`.
+
+This is **THE template for an out-of-tree user project** (a separate colcon
+workspace that consumes the core). The split it enforces:
+
+- **core** = engine + **model library** (`assets/models/`) + worlds. **No
+  controllers**: `vessel_cmd_array` is only *consumed* there by `physics_interface_plugin`.
+- **generic-scenario** = **behaviors** (one **ROS2 package per agent**, with the
+  usual double package dir: `src/agents/<name>/<name>/<name>.py`) + **scenarios** (JSON config in
+  `src/simulation_run/config/`) + bridges (`src/gz_ros2_bridge`) + the Unity player.
+- **your own project** = the demo plumbing (scripts, Blender mesh sources, captures).
+
+**Controller pattern** (where a pilot goes):
+`src/external_packages/lrauv_propeller/lrauv_propeller/lrauv_propeller.py`
+inherits the agent class, creates a publisher on `/<world>/vessel_cmd_array` and sends
+`{"<thruster>(rpm)": …}`. That one is **open-loop** (an rpm sequence on a timer)
+on a **thruster**; a **closed-loop** controller (P-control on the pose) and/or
+**angle-commanded actuators** (sail/rudder) are legitimate extensions. → a new
+pilot goes in `src/agents/<name>/`, **not** in the core.
+
+## The three Unity repos (`naval-group/…`)
+
+| Repo | Role |
+|---|---|
+| `LOTUSim-Unity-modules` | the main Unity project (scenes, `lotusim_interface`). |
+| `LOTUSim-Unity-ros-tcp-endpoint` | the bridge receiver (fork of Unity Robotics ROS-TCP-Endpoint, ros2). Build: `colcon build --merge-install --packages-select ros_tcp_endpoint`. |
+| `LOTUSim-Unity-custom-hdrp` | HDRP fork (sea/physics rendering). In production the manifest may point to the HDRP registry rather than this fork. |
+
+## Data flow: gz ↔ xdyn ↔ Unity
+
+A vessel has three data flows. Knowing them avoids silent orientation bugs and
+"connected but nothing renders".
+
+```
+              commands (out)                 state (in)               render (out)
+ROS2 vessel_cmd_array ─► gz physics_engine ─► xdyn ─► gz entity pose ─► render_plugin ─► Unity
+   (thrusters / control surfaces)  (websocket)      (quaternion NED→ENU)  (ROS2/TCPUDP)   (Z→-Y)
+```
+
+### Commanding a vessel (commands → xdyn)
+
+xdyn **ignores** the yaml `commands:` block. Setpoints are **published** on
+`/<world>/vessel_cmd_array` (`lotusim_msgs/msg/VesselCmdArray`); each
+`VesselCmd.cmd_string` is JSON `{"<xdyn signal>": <value>}` forwarded verbatim.
+
+- **Propellers** (`<thrusters>` in `<lotus_param>`) → signals `<name>(rpm)`,
+  `<name>(P/D)`, `<name>(beta)`. With no publisher → hardcoded default `(rpm)=2.0`
+  ≈ zero thrust.
+- **Angle-commanded actuators** (sails, rudder, fins) are xdyn *force models*
+  (`hydrodynamic polar`) commanded by their **full signal**
+  `<force model>(<angle command>)`, e.g. `mainsail(sail)`, `rudder(angle)`. The
+  default command template is built from `<thrusters>` only, so an angle-commanded
+  force model has no default command and must be seeded before the first ROS setpoint.
+
+### Return state (xdyn → gz) — coordinate conventions
+
+- **xdyn = NED frame** (North-East-Down); body = X-fwd, Y-stbd, Z-down; rotation
+  `Z/Y/X` `[psi, theta', phi'']` (the only supported convention).
+- **Quaternion**: order `qr, qi, qj, qk` (real first), matching xdyn's wire spec.
+  The receive path (`xdyn_websocket.cpp`) must rebuild them in that order
+  (`Quaterniond(qr, qi, qj, qk)`) before the frame conversion; if receive and
+  send disagree, a yaw comes back as roll and heading never accumulates
+  (invisible at identity orientation).
+- **NED → ENU**: `quatNedToEnu()` / `vecNedToEnu()` convert xdyn's NED state into
+  Gazebo's right-handed **ENU (Z-up)** frame. A **separate** step, downstream of parsing.
+
+### Rendering (gz → Unity)
+
+Production LOTUSim rendering is **Unity**, not the gz GUI (many models have no
+`<visual>` → invisible in gz). The bridge:
+
+- **World** plugin `<plugin filename="render_plugin" name="lotusim::gazebo::RenderPlugin">`
+  with `<connection_protocol>` = **`ROS2`** or **`TCPUDP`** (the only accepted values).
+- Per vessel, in `<lotus_param>`: `<render_interface><publish_render>true</publish_render>
+  <renderer_type_name>NAME</renderer_type_name></render_interface>`.
+- Over ROS2 the gz node is **namespaced by the world name** → topics
+  `/<world>/renderer_cmd` (`RendererCmd`: CREATE/DELETE, QoS TRANSIENT_LOCAL+RELIABLE)
+  and `/<world>/renderer_poses` (`VesselPositionArray`, each tick). On the Unity
+  side, `LotusimInterface.m_namespace` **must** equal the world name (the
+  "connected, nothing renders" trap).
+- **The mesh does NOT travel** on the wire: the flow carries a *name* + poses.
+  Unity resolves the mesh via **Addressables**
+  (`Addressables.LoadAssetAsync<GameObject>(renderer_obj_name)`) → a Unity prefab
+  whose Addressable address == `renderer_type_name`.
+- **Latched CREATE**: gz publishes CREATE as TRANSIENT_LOCAL at spawn; if Unity
+  subscribes later, re-emit CREATE (restart gz, or publish manually with
+  `--qos-durability transient_local --qos-reliability reliable`).
+- **Frame conversion, Unity side** (`Assets/Scripts/lotusim_interface/common.cs`,
+  `CoordinateSystemUtils.GzPoseToUnityPose`): Unity is **left-handed, Y-up**;
+  position `(x, z, y)`, rotation `(-x, -z, -y, w)` — the documented `Z→-Y`. A
+  fixed, generic transform applied to every gz pose (independent of xdyn).

--- a/.agents/skills/lotusim-developer/references/models-and-worlds.md
+++ b/.agents/skills/lotusim-developer/references/models-and-worlds.md
@@ -1,0 +1,193 @@
+# Anatomy of a model and a world
+
+> **Scope**: this file covers the **model** (assets, in the **core**) and the
+> **world**. A vessel's **behavior/controller** does **not** live here — it goes
+> in **`LOTUSim-generic-scenario`** (`src/agents/`), see `architecture.md`.
+
+## Model: `assets/models/<name>/`
+
+```
+<name>/
+├── model.config     # Gazebo metadata, points at model.sdf
+├── model.sdf        # SDF (version varies by model, 1.6–1.10): links, collision, sensors (often NO visual)
+├── <name>.yaml      # xdyn model: ALL the dynamics (naming is loose: .yaml/.yml/…Config.yaml)
+└── meshes/          # .dae (rendering) + .stl (xdyn hydrostatics)
+```
+
+### model.config
+
+```xml
+<?xml version="1.0"?>
+<model>
+  <name>BlueBoat</name>
+  <version>1.0</version>
+  <sdf version="1.7">model.sdf</sdf>
+  <author><name>...</name></author>
+  <maintainer>...</maintainer>
+  <description>...</description>
+</model>
+```
+
+### model.sdf (minimal — by design)
+
+The `model.sdf` is **small**: a `base_link` with a **collision** geometry and
+custom sensors. **No physics plugin here** (the dynamics come from xdyn), and
+often **no `<visual>` or inertial**. A typical AIS sensor: `gz:type="ais"`.
+
+```xml
+<?xml version="1.0"?>
+<sdf version="1.10">
+  <model name="blueboat">
+    <link name="base_link">
+      <collision name="base_collision">
+        <geometry><mesh><uri>model://blueboat/meshes/blueboat.stl</uri></mesh></geometry>
+      </collision>
+      <!-- ADD to see it in the Gazebo GUI (cf. fremm/commando): -->
+      <visual name="visual">
+        <geometry><mesh><uri>model://blueboat/meshes/blueboat.dae</uri></mesh></geometry>
+      </visual>
+      <sensor name="ais" type="custom" gz:type="ais">
+        <update_rate>1</update_rate>
+        <noise_sigma>0.01</noise_sigma>
+        <noise_amplitude>0.01</noise_amplitude>
+      </sensor>
+    </link>
+  </model>
+</sdf>
+```
+
+### Visual vs Unity (important)
+
+| Rendered in | Models | `<visual>` in model.sdf |
+|---|---|---|
+| **Unity** (`render_plugin`→ROS2→prefab) | wamv, dtmb_hull, lrauv, mine, pha, bluerov2_heavy | no (collision only) |
+| **Gazebo** (direct) | fremm, commando, landscape, x500 | yes |
+
+Consequence: a "collision-only" model is **invisible in the gz GUI** (toggle
+*Entity Tree → right-click → View → Collisions* to see it). Giving a vehicle a
+Unity look = a **HDRP prefab** in `LOTUSim-Unity-modules` + a name→prefab mapping
+(`LotusimBaseInterface.cs`, *"Maps vessel names to prefab names"*) — a separate,
+heavy art pipeline. For a self-contained demo/contribution: give it a gz
+`<visual>` (a legitimate pattern, cf. fremm/commando).
+
+⚠️ A `<visual>` alone is not enough to SEE it in the gz GUI: many LOTUSim worlds
+(e.g. `xdyn_multithread_test`) don't embed the `SceneBroadcaster` (they render in
+Unity; some worlds like `defenseScenario` do include it). Add to the world
+`<plugin filename="gz-sim-scene-broadcaster-system" name="gz::sim::systems::SceneBroadcaster"/>`
+to render the `<visual>` in gz (and publish the pose topics, cf. the oracle).
+
+⚠️ **Orientation — LOTUSim convention: the mesh's bow is on +y** (measured on
+`fremm.dae`: 142 m in y, 24 m in x). A bow-on-+x mesh renders **sideways**
+("crabbing", 90° off heading). Fix: model the bow on +y, or add
+`<pose>0 0 0 0 0 1.5708</pose>` on the `<visual>`. The physics (STL/xdyn) is not
+affected — this is purely rendering.
+
+### The xdyn model file (`.yaml`/`.yml`) — the dynamics
+
+This is where the physics lives. Structure (cf. `wamv.yaml`, `dtmb-xdyn.yml`,
+`lrauv.yml`):
+
+```yaml
+rotations convention: [psi, theta', phi'']
+environmental constants:
+    g:   {value: 9.81, unit: m/s^2}
+    rho: {value: 1025, unit: kg/m^3}        # seawater
+    nu:  {value: 1.18e-6, unit: m^2/s}
+environment models:
+    - model: no wind
+    - model: no waves
+      constant sea elevation in NED frame: {value: 0, unit: m}
+    - model: ekman current        # or 'no current'
+      ...
+bodies:
+  - name: BLUEBOAT
+    mesh: blueboat/meshes/blueboat.stl       # for hydrostatics + Froude-Krylov
+    position of body frame relative to mesh: { frame: mesh, x/y/z/phi/theta/psi }
+    initial position of body frame relative to NED: { frame: NED, ... }
+    initial velocity of body frame relative to NED: { frame: BLUEBOAT, u/v/w/p/q/r }
+    dynamics:
+        hydrodynamic forces calculation point in body frame: { x,y,z }
+        centre of inertia: { frame: BLUEBOAT, x,y,z }
+        rigid body inertia matrix at the center of gravity and projected in the body frame:
+            row 1..6: [ ... 6x6 ... ]
+        added mass matrix at the center of gravity and projected in the body frame:
+            row 1..6: [ ... 6x6 ... ]
+        # + damping, and PROPULSION (named thrusters — see below)
+```
+
+**Propulsion** defines **named** actuators (e.g. `PSPropRudd`, `SBPropRudd` on
+dtmb for a twin layout) — these names must match the world's `<thrusters>`. Take
+inspiration from `lrauv` (Wageningen B-series propeller) and `dtmb_hull` (twin).
+Deprecated xdyn keys are tolerated (warnings "center of buoyancy" → prefer
+"center of gravity").
+
+### Generating the meshes (Blender)
+
+Two meshes per model: **`<name>.dae`** (COLLADA visual, if the model gets a
+`<visual>`) and **`<name>.stl`** (a *closed* hull for xdyn hydrostatics,
+referenced by `<name>.yaml`).
+
+- **Blender 4.5 LTS, not 5.0**: the **COLLADA `.dae`** exporter exists in 4.5
+  (removed in 5.0).
+- **STL: normals facing outward.** xdyn warns `N facets seem oriented inwards`
+  if the normals are inconsistent (a vertex edit can flip them) → wrong
+  hydrostatics. In Blender: Edit Mode → `normals_make_consistent(inside=False)`
+  before the STL export.
+- **Unity import gotcha**: Blender 4.5's COLLADA `.dae` export is **broken for
+  Unity import** (produces empty `<instance_geometry>` → empty import). For Unity,
+  export **FBX** with `bake_space_transform=True, axis_forward='-Z', axis_up='Y'`
+  (Blender's Z-up → Unity's Y-up baked into the vertices, root at identity —
+  critical, since the pose flow overwrites the root rotation).
+
+## World: `assets/worlds/*.world`
+
+Plugins **at world level** (once), then each vehicle as an `<include>`.
+
+```xml
+<sdf version="1.7">
+  <world name="lotusim">
+    <gravity>0 0 0</gravity>          <!-- xdyn does ALL the forces, not gz -->
+    <plugin filename="physics_interface_plugin" name="lotusim::gazebo::PhysicsInterfacePlugin"/>
+    <plugin filename="entity_manager_plugin"   name="lotusim::gazebo::EntityManager"/>
+    <plugin filename="lotusim_sensor_plugin"   name="lotusim::sensor::LotusimSensorPlugin"/>
+    <plugin filename="render_plugin"           name="lotusim::gazebo::RenderPlugin">
+        <connection_protocol>ROS2</connection_protocol>
+    </plugin>
+    <plugin filename="waypoint_plugin"         name="lotusim::gazebo::WaypointFollowerPlugin"/>
+
+    <include>
+      <uri>model://blueboat</uri>
+      <name>blueboat1</name>
+      <pose>0 0 0 0 0 0</pose>
+      <lotus_param>
+        <physics_engine_interface>            <!-- wire the vessel to an xdyn server -->
+          <surface>
+            <connection_type>XDynWebSocket</connection_type>
+            <uri>ws://127.0.0.1:12345</uri>   <!-- one unique port per vessel -->
+            <thrusters>
+              <thruster1>PSPropRudd</thruster1>   <!-- names = those in the xdyn yaml -->
+              <thruster2>SBPropRudd</thruster2>
+            </thrusters>
+          </surface>
+          <init_state>Surface</init_state>
+        </physics_engine_interface>
+        <render_interface>
+          <publish_render>true</publish_render>
+          <renderer_type_name>wamv</renderer_type_name>   <!-- Unity prefab key -->
+        </render_interface>
+      </lotus_param>
+    </include>
+  </world>
+</sdf>
+```
+
+⚠️ `<physics_engine_interface>` (co-sim) and `<waypoint_follower>` are
+**mutually exclusive** per vessel — no shipped world combines them (cf. pitfall
+#6). The `<include>` above is the co-sim path; for a purely kinematic vessel,
+replace `<physics_engine_interface>` with a `<waypoint_follower>` block (see
+`circling_ship_example.world`).
+
+Reference worlds: `circling_ship_example.world` (1 kinematic vessel, no
+`physics_engine_interface`), `xdyn_multithread_test.world` (2 vessels with xdyn
+on 12345/12346). The default model loaded by `entity_manager` is `model.sdf`
+(overridable via `sdf_file`).

--- a/.agents/skills/lotusim-developer/references/run-and-verify.md
+++ b/.agents/skills/lotusim-developer/references/run-and-verify.md
@@ -1,0 +1,114 @@
+# Running with physics & verifying
+
+## The co-simulation architecture (the key point)
+
+```
+   xdyn-for-cs (websocket server, 1 per vessel)          gz sim (Gazebo)
+   ws://127.0.0.1:12345  <───────────────────────────  physics_interface_plugin (client)
+        ^                                                       │
+        │ dynamics (xdyn reads <name>.yaml)                     │ pose, waypoint, sensors
+```
+
+- `physics_interface_plugin` (inside gz) is a **client**; it reads the `<uri>`
+  from the world's `<lotus_param><physics_engine_interface>` and connects.
+- `xdyn-for-cs` (prebuilt binary in `physics/`) is the **server**: it computes
+  the 6-DOF dynamics from `<name>.yaml`. **One process per vessel**, each on a
+  unique port (12345, 12346, …).
+- `lotusim run` **launches gz ONLY**. You must start xdyn separately, otherwise:
+  `XdynWebsocket::onFail: Failed ws://… → loadVessel: Loading failed, Removing physics`.
+
+### Launching xdyn-for-cs
+
+```bash
+xdyn-for-cs <model>.yaml --address 127.0.0.1 --port 12345 --dt 0.2
+#   --dt 0.2 = time step ; -s rk4 by default (euler/rkck available)
+#   --verbose to see the exchanges ; -w for the websocket detail
+```
+
+Reference orchestrator (multi-agent, the "real" launcher):
+`LOTUSim-generic-scenario/src/simulation_run/executable/scenario_launch.sh`
+(starts one `xdyn-for-cs agent.yml --port $port --dt 0.2` per agent, then gz,
+and `pkill -f xdyn-for-cs` on cleanup).
+
+For a local run, a small wrapper typically starts one xdyn server per port, then
+`gz`, and **kills the servers by PID via a `trap`** (never `pkill` — see runtime
+pitfalls).
+
+## Launching gz (Harmonic)
+
+```bash
+lotusim run <world>.world          # headless (gz sim -s) — default
+lotusim run --gui <world>.world    # with GUI
+# direct: gz sim -s -v3 -r <world>   (-s server only, -r run, -v3/-v4 verbosity)
+```
+
+The wrapper sets `GZ_SIM_SYSTEM_PLUGIN_PATH=install/lib`,
+`GZ_SIM_RESOURCE_PATH=assets/models`. Prefix **`gz`** (Harmonic), not `ign`.
+
+## Verifying (oracle = displacement)
+
+For "it floats + it moves", the robust oracle is the **displacement measured in
+the sim** (not the rendering — EGL/OGRE2 is fragile in headless/remote setups;
+never gate pass/fail on it). Headless loop:
+
+```
+build → validate SDF (gz sdf -k <file>) → [xdyn server(s)] → spawn headless (gz sim -s -r)
+      → read start/end pose → assert dist > threshold → (artifact: trajectory plot)
+```
+
+Log signals to assert:
+
+- `physics in domain Surface init completed` + `XdynWebsocket::onOpen` → physics OK;
+- `onFail` / `unable to connect` → no xdyn server / port-uri mismatch;
+- `Failed to load system plugin` → plugin path (`GZ_SIM_SYSTEM_PLUGIN_PATH`) or build;
+- `dist ≈ 0` → sank (bad hydrostatics) or no thrust (no setpoint on `vessel_cmd_array`).
+
+### Thrust source in co-sim (PITFALL #6): `vessel_cmd_array`, not the yaml or the waypoint
+
+`xdyn-for-cs` **ignores** the yaml `commands:` block. Thrust is **published** on
+the ROS2 topic `/<world>/vessel_cmd_array` (`lotusim_msgs/msg/VesselCmdArray`):
+`physics_interface_plugin` subscribes and forwards `VesselCmd.cmd_string` (JSON)
+to xdyn. `cmd_string` keys = `"<thruster>(<param>)"`, params `rpm` / `P/D` /
+`beta`; the names must match the world's `<thrusters>` AND the yaml's actuators.
+With no publisher → hardcoded default `rpm=2.0` → near-zero thrust. The
+`waypoint_follower` is NOT this source (status only, kinematic mode). Minimal
+publisher:
+
+```python
+# pub_thrust.py — makes a vessel move under physics (co-sim)
+import json, rclpy
+from rclpy.node import Node
+from lotusim_msgs.msg import VesselCmd, VesselCmdArray
+rclpy.init(); n = Node("thrust_pub")
+pub = n.create_publisher(VesselCmdArray, "/lotusim/vessel_cmd_array", 10)
+cmd = json.dumps({"PSthruster(rpm)": 250.0, "SBthruster(rpm)": 250.0})
+n.create_timer(0.1, lambda: pub.publish(
+    VesselCmdArray(cmds=[VesselCmd(vessel_name="blueboat", cmd_string=cmd)])))
+rclpy.spin(n)
+```
+
+### Reading the pose (oracle) → you need the `SceneBroadcaster`
+
+Many LOTUSim worlds (e.g. `xdyn_multithread_test`) render in Unity and **don't
+embed** `gz-sim-scene-broadcaster-system` → no pose topic (and invisible in the
+gz GUI). To measure displacement (and
+render in gz), add to the world
+`<plugin filename="gz-sim-scene-broadcaster-system" name="gz::sim::systems::SceneBroadcaster"/>`,
+then read `/world/<world>/dynamic_pose/info` (`gz topic -e … --json-output`),
+extract the vessel pose (jq) and assert the horizontal displacement.
+
+## Runtime pitfalls
+
+- **Shell**: launch via the `lotusim` wrapper (bash) or source `setup.zsh` under zsh.
+- **Suicidal pkill**: `pkill -f "gz sim"`/`xdyn-for-cs` matches your own command
+  line → self-kill (exit ~144). Capture `$!` and `kill`, or use a `trap`.
+- **Ports**: one per vessel; must match the world's `<uri>`.
+- **Gravity 0** in the worlds: normal, xdyn does all the dynamics.
+- **`set -u`**: NEVER enable it before sourcing the ROS env (`setup.bash`
+  references undefined vars → the script dies silently, exit 1 with no output).
+- **`gz sdf -k`**: validates a `model.sdf` but **fails on a world** with
+  `<include>` (`Unable to find uri[model://…]`, no find-callback) → validate a
+  world by spawning it, not with `-k`.
+- **Crabbing mesh**: LOTUSim convention = mesh bow on **+y** (cf. `models-and-worlds.md`).
+- **GUI screenshot**: the `/gui/screenshot` service wants a **directory** (it
+  drops a timestamped PNG there), not a file path.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,111 @@
+# AGENTS.md — LOTUSim
+
+Orientation for coding agents (and new human contributors) working in this
+repository. LOTUSim is an open-source (EPL-2.0) multi-agent naval simulator:
+ROS2 + Gazebo for orchestration and rendering, xdyn for rigid-body dynamics,
+coupled in co-simulation.
+
+## Read this first: physics is an external server
+
+Physics is not a Gazebo plugin — it is an external `xdyn` process. The Gazebo
+`physics_engine_interface` is a websocket client that connects to an
+`xdyn-for-cs` server (one per vessel, on a TCP port). `lotusim run` launches
+only `gz`, not xdyn. Without an xdyn server listening, a vessel spawns and
+renders but has zero dynamics (log: `XdynWebsocket::onFail ... Removing physics`).
+
+## Environment
+
+- Ubuntu 24.04 → ROS2 Jazzy + Gazebo Harmonic (prefix `gz`, not `ign`).
+- ROS setup scripts assume bash; under zsh, source the `.zsh` variant (`setup.zsh`) or use the `lotusim` wrapper.
+
+Two ways to get a working stack — the container is the reproducible one.
+
+### Container (recommended)
+
+A prebuilt image ships the full ROS2 + Gazebo + built LOTUSim workspace:
+
+    docker pull ghcr.io/naval-group/lotusim:latest   # release also tags :<short-sha>
+    docker run --rm -it ghcr.io/naval-group/lotusim:latest bash
+
+Build/test a local change against the image's prebuilt workspace — mount your
+source, rebuild only the affected package:
+
+    docker run --rm -v "$PWD":/lotusim_ws/src/LOTUSim ghcr.io/naval-group/lotusim:latest \
+      bash -c 'source /opt/ros/$ROS_DISTRO/setup.bash && source /lotusim_ws/install/setup.bash \
+               && cd /lotusim_ws && colcon build --merge-install --packages-select <pkg>'
+
+Headless (no GUI) — use it for builds, tests, and headless runs.
+
+### Native
+
+    lotusim install        # one-time: deps + build
+    lotusim build          # rebuild workspace (colcon, --merge-install); clean_build to start over
+    colcon build --merge-install --packages-select <pkg>   # single package
+
+## Run a world
+
+- With physics: start one `xdyn-for-cs` per vessel (each on its port), then
+  `lotusim run <world>.world`. Success log:
+  `PhysicsInterfacePlugin::loadVessel: ... Surface init completed` + `onOpen`.
+- Without physics (render / plugin debug): `lotusim run --gui <world>.world`.
+
+## Move a vessel under physics
+
+Thrust comes neither from the yaml `commands:` block nor from `waypoint_follower`
+(a separate kinematic mode). Publish `lotusim_msgs/msg/VesselCmdArray` on
+`/<world>/vessel_cmd_array`; each `VesselCmd.cmd_string` is JSON
+`{"<thruster>(rpm)": <val>, ...}` forwarded to xdyn. Reference controllers live
+in the `LOTUSim-generic-scenario` repo, not in this core.
+
+## Add a vehicle (the typical contribution)
+
+A model lives in `assets/models/<name>/`: `model.config`, `model.sdf` (SDF;
+version varies by model, 1.6–1.10), an xdyn model file (naming varies:
+`wamv.yaml`, `dtmb-xdyn.yml`, `fremmConfig.yaml`, …) holding the dynamics
+(inertia, added mass, damping, propulsion), and `meshes/`. Wire it into a world
+via `<include>` + `<lotus_param>`.
+The model (assets) goes in this core; its controller/scenario goes in
+`LOTUSim-generic-scenario`. Deep dive: `.agents/skills/lotusim-developer/references/models-and-worlds.md`.
+
+## Coordinate conventions
+
+xdyn is NED, right-handed; Gazebo is ENU. Quaternion wire order is
+`qr, qi, qj, qk` (= w, x, y, z), by name. Gazebo↔Unity applies a `Z → -Y`
+transform on the Unity side.
+
+## Contributing
+
+Issue (with the appropriate label) → announce yourself → fork → implement →
+test → PR referencing the issue (see `CONTRIBUTING.md`). EPL-2.0: never vendor
+GPL or non-redistributable assets. Whoever opens the PR answers for every line,
+AI-assisted or not; disclosing AI assistance (e.g. an `Assisted-by:` commit
+trailer) is good practice, though the project has no formal policy on it yet.
+
+## Related repositories (naval-group)
+
+LOTUSim spans several repos — this core is only the simulation backend.
+
+- **LOTUSim** — this repo: the simulator core (ROS2 + Gazebo + xdyn co-sim).
+- **LOTUSim-Xdyn** — the xdyn physics engine, a fork/mirror of the canonical
+  upstream at `gitlab.com/sirehna_naval_group/sirehna/xdyn`. Engine fixes go to
+  the **GitLab upstream**, not this GitHub mirror.
+- **LOTUSim-generic-scenario** — reference controllers/scenarios (`src/agents/`),
+  the auto-installer, and a prebuilt Unity player. Vessel *controllers* live here,
+  not in this core.
+- **LOTUSim-Unity-modules**, **LOTUSim-Unity-custom-hdrp** (HDRP fork),
+  **LOTUSim-Unity-ros-tcp-endpoint** (Unity↔ROS bridge) — the Unity rendering
+  frontend (an alternative to the Gazebo GUI).
+- **LOTUSim-UI-frontend** (React), **LOTUSim-UI-backend** — the web UI.
+- **LOTUSim-multi-agents-benchmark** — multi-agent benchmarking.
+
+## Further reading
+
+- **Project wiki** — authoritative human docs (xdyn User Guide, model/world
+  formats, testing): https://github.com/naval-group/LOTUSim/wiki
+- **Coding-agent skill** — `.agents/skills/lotusim-developer/` ships a deeper,
+  task-oriented map. Its `SKILL.md` opens with 6 field-tested pitfalls; to enable
+  it in your agent (Codex, Claude Code, …), see
+  `.agents/skills/lotusim-developer/README.md`. Deep-dive references:
+  - `references/architecture.md` — co-sim data flow (gz ↔ xdyn ↔ Unity), ecosystem repos, coordinate conventions
+  - `references/models-and-worlds.md` — model/world anatomy, adding a vehicle
+  - `references/run-and-verify.md` — xdyn orchestration, verifying a vessel actually moves


### PR DESCRIPTION
## What

Onboarding docs for coding agents (and new human contributors) — **docs only, no code changes**:

- **`AGENTS.md`** (repo root) — the vendor-neutral entry point every agent reads
  with no setup: physics is an external xdyn co-sim server, environment
  (container + native), build/run, moving a vessel under physics, adding a
  vehicle, coordinate conventions, the naval-group repo map, and the
  contribution workflow.
- **`.agents/skills/lotusim-developer/`** — a deeper, task-oriented skill in the
  open agent-skill format (works with Codex, Claude Code, and others): a
  `SKILL.md` opening with 6 field-tested pitfalls, `references/` (architecture,
  models-and-worlds, run-and-verify), and a `README.md` with per-harness install
  steps. `AGENTS.md` stays the universal baseline; the skill is opt-in.

## Why

The repo has no `AGENTS.md` or in-repo agent guidance today; the non-obvious
knowledge (co-sim architecture, the xdyn-is-external gotcha, model/world anatomy)
lives in the wiki or is learned the hard way. This lowers the ramp for agentic
and human contributors, and keeps the wiki as the source of truth for
authoritative details.

## Verification

Content was fact-checked against this repo and the sibling repos: a multi-agent
review verified ~120 concrete claims (SDF tag `<lotus_param>`, topics, QoS, log
strings, controller paths, model/file names, SDF versions, published Docker
tags), which caught and fixed ~a dozen one-line inaccuracies before this PR.

## Note on AI-assistance disclosure

Authored with Claude Opus 4.8 and independently fact-checked with a Claude
Fable 5 multi-agent review (see the `Assisted-by:` trailers). The `AGENTS.md`
"Contributing" section frames disclosing AI assistance as *good practice* — it
does **not** claim an existing project policy. If the maintainers want a formal
AI-contribution policy, happy to adjust the wording or split that out.

## Related

`references/architecture.md` documents the correct xdyn quaternion wire order
(`qr, qi, qj, qk`); the actual receive-path bug is addressed separately in
#27 / #28.
