### PR TITLE
Test(physics_engine_interface): bootstrap gtest unit tests + advisory CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,23 @@ jobs:
         with:
           context: .
           push: false
+          load: true
           build-args: |
             ROS_DISTRO=${{ matrix.ros }}
           tags: lotusim:${{ matrix.ros }}
+
+      # Advisory: runs the unit tests but does not gate the build while the
+      # project has no established test culture. Promote to a required check
+      # once test coverage is expected on logic PRs.
+      - name: Unit tests (advisory)
+        continue-on-error: true
+        run: |
+          docker run --rm lotusim:${{ matrix.ros }} bash -c '
+            source /opt/ros/${{ matrix.ros }}/setup.bash &&
+            source "$LOTUSIM_WS/install/setup.bash" &&
+            cd "$LOTUSIM_WS" &&
+            colcon build --packages-select physics_engine_interface \
+              --merge-install --cmake-args -DBUILD_TESTING=ON &&
+            colcon test --packages-select physics_engine_interface \
+              --merge-install --event-handlers console_direct+ &&
+            colcon test-result --verbose'

--- a/systems/physics_engine_interface/CMakeLists.txt
+++ b/systems/physics_engine_interface/CMakeLists.txt
@@ -96,6 +96,24 @@ install(
 )
 
 #============================================================================
+# Testing
+#============================================================================
+if(BUILD_TESTING)
+  find_package(ament_cmake_gtest REQUIRED)
+
+  # Unit tests on the NED<->ENU conversions (pure functions living in the
+  # plugin library). The test forward-declares them and links the library, so
+  # it does not need the plugin's websocketpp/json include chain.
+  ament_add_gtest(test_ned_enu_conversions test/test_ned_enu_conversions.cpp)
+  if(TARGET test_ned_enu_conversions)
+    target_link_libraries(test_ned_enu_conversions
+      physics_interface_plugin
+      gz-sim8::gz-sim8
+    )
+  endif()
+endif()
+
+#============================================================================
 # Export
 #============================================================================
 ament_export_targets(export_physics_interface_plugin HAS_LIBRARY_TARGET)

--- a/systems/physics_engine_interface/package.xml
+++ b/systems/physics_engine_interface/package.xml
@@ -16,6 +16,8 @@
   <depend>lotusim_msgs</depend>
   <depend>lotusim_common</depend>
 
+  <test_depend>ament_cmake_gtest</test_depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/systems/physics_engine_interface/test/test_ned_enu_conversions.cpp
+++ b/systems/physics_engine_interface/test/test_ned_enu_conversions.cpp
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2025 Naval Group
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+#include <gtest/gtest.h>
+
+#include <gz/math/Quaternion.hh>
+#include <gz/math/Vector3.hh>
+
+#include <cmath>
+
+// These free functions are defined in physics_interface_plugin
+// (src/xdyn_websocket.cpp) and declared in xdyn_websocket.hpp. They are
+// forward-declared here so the test does not pull in the plugin's heavy
+// websocketpp / nlohmann-json includes; the test links the library to resolve
+// them at link time.
+namespace lotusim::gazebo {
+gz::math::Quaterniond quatNedToEnu(const gz::math::Quaterniond& q_ned);
+gz::math::Quaterniond quatEnuToNed(const gz::math::Quaterniond& q_enu);
+gz::math::Vector3d vecNedToEnu(const gz::math::Vector3d& v_ned);
+gz::math::Vector3d vecEnuToNed(const gz::math::Vector3d& v_enu);
+}  // namespace lotusim::gazebo
+
+using gz::math::Quaterniond;
+using gz::math::Vector3d;
+using lotusim::gazebo::quatEnuToNed;
+using lotusim::gazebo::quatNedToEnu;
+using lotusim::gazebo::vecEnuToNed;
+using lotusim::gazebo::vecNedToEnu;
+
+namespace {
+constexpr double kTol = 1e-9;
+
+const Quaterniond kIdentity(1.0, 0.0, 0.0, 0.0);
+
+void expectQuatNear(const Quaterniond& a, const Quaterniond& b, double tol = kTol)
+{
+    EXPECT_NEAR(a.W(), b.W(), tol);
+    EXPECT_NEAR(a.X(), b.X(), tol);
+    EXPECT_NEAR(a.Y(), b.Y(), tol);
+    EXPECT_NEAR(a.Z(), b.Z(), tol);
+}
+}  // namespace
+
+// NED (X=North, Y=East, Z=Down) -> ENU (X=East, Y=North, Z=Up):
+// swap X/Y, flip Z.
+TEST(NedEnuConversions, VecNedToEnuKnownValue)
+{
+    const Vector3d enu = vecNedToEnu({1.0, 2.0, 3.0});
+    EXPECT_NEAR(enu.X(), 2.0, kTol);
+    EXPECT_NEAR(enu.Y(), 1.0, kTol);
+    EXPECT_NEAR(enu.Z(), -3.0, kTol);
+}
+
+// The axis permutation is its own inverse: NED->ENU->NED is the identity.
+// vecNedToEnu and vecEnuToNed share the same body on purpose (the swap is an
+// involution) — this guards that from being "fixed" into a real bug.
+TEST(NedEnuConversions, VecRoundTripIsIdentity)
+{
+    const Vector3d v{1.0, 2.0, 3.0};
+    const Vector3d back = vecEnuToNed(vecNedToEnu(v));
+    EXPECT_NEAR(back.X(), v.X(), kTol);
+    EXPECT_NEAR(back.Y(), v.Y(), kTol);
+    EXPECT_NEAR(back.Z(), v.Z(), kTol);
+}
+
+// An orientation converted NED->ENU->NED must come back unchanged.
+TEST(NedEnuConversions, QuatRoundTripIsIdentity)
+{
+    const double d2r = M_PI / 180.0;
+    const Quaterniond q(12.0 * d2r, -8.0 * d2r, 30.0 * d2r);  // roll, pitch, yaw
+    expectQuatNear(q, quatEnuToNed(quatNedToEnu(q)));
+}
+
+// A level orientation stays level.
+TEST(NedEnuConversions, IdentityMapsToIdentity)
+{
+    expectQuatNear(kIdentity, quatNedToEnu(kIdentity));
+}
+
+// Heading sign flips between frames: a +90 deg NED heading (clockwise from
+// North, about Down) is a -90 deg ENU yaw (counter-clockwise from East, about
+// Up). This is exactly the class of axis/handedness error a broken quaternion
+// mapping produces (cf. the xdyn qj/qk fix).
+TEST(NedEnuConversions, NedHeadingBecomesOppositeEnuYaw)
+{
+    const double yaw_ned = 90.0 * M_PI / 180.0;
+    const Quaterniond q_ned(0.0, 0.0, yaw_ned);
+    const Vector3d euler = quatNedToEnu(q_ned).Euler();  // roll, pitch, yaw
+    EXPECT_NEAR(euler.X(), 0.0, 1e-6);
+    EXPECT_NEAR(euler.Y(), 0.0, 1e-6);
+    EXPECT_NEAR(euler.Z(), -yaw_ned, 1e-6);
+}


### PR DESCRIPTION
## Why

The project has no unit-test scaffolding: `colcon test` runs nothing and CI only
builds the Docker image. Yet `CONTRIBUTING.md` step 4 asks every contribution to
"pass all tests" — today that check is vacuous. This PR establishes the harness
so future logic PRs (including upcoming fixes) can ship with tests instead of
re-litigating the framework each time.

## What

- Wire `ament_cmake_gtest` into `physics_engine_interface` (`<test_depend>` +
  an `if(BUILD_TESTING)` block).
- Add `test/test_ned_enu_conversions.cpp` covering the **existing** NED<->ENU
  conversions (`vec/quat NedToEnu/EnuToNed`) — pure functions, and the exact
  neighbourhood of past coordinate/quaternion issues. Cases: known-value,
  round-trip identity, and heading semantics (a +90 deg NED heading is a -90 deg
  ENU yaw).
- CI gains an **advisory** (`continue-on-error: true`) `colcon test` step: it
  runs and reports but does not gate merges while the project has no established
  test culture. Promote it to a required check once tests are expected on logic
  PRs.

## Test placement — ROS2/ament convention

Tests live in `systems/physics_engine_interface/test/`, i.e. per package next to
`src/`/`include/`. This is the ROS2/ament standard (`ament_add_gtest(name
test/...)`, matching the `test/` dir `ros2 pkg create` scaffolds for
ament_python). C++ has no single test-layout convention, so we follow the
ecosystem's rather than inventing one.

## Proof

Runs green on both CI legs (jazzy + humble): `[  PASSED  ] 5 tests`,
`100% tests passed, 0 tests failed`. Scoped to one package, no production code
touched.
