### PR TITLE
Fix(physics_engine_interface): include body-frame swap in NED<->ENU attitude conversion

### DIFF
--- a/systems/physics_engine_interface/include/physics_engine_interface/xdyn_websocket.hpp
+++ b/systems/physics_engine_interface/include/physics_engine_interface/xdyn_websocket.hpp
@@ -31,6 +31,8 @@ using json = nlohmann::json;
 
 static const gz::math::Quaterniond
     q_ned_to_enu(0.0, 0.70710678118, 0.70710678118, 0.0);
+// Body-frame convention swap (gz FLU <-> xdyn FRD): 180 deg about body-x.
+static const gz::math::Quaterniond q_flu_to_frd(0.0, 1.0, 0.0, 0.0);
 
 gz::math::Quaterniond quatNedToEnu(const gz::math::Quaterniond& q_ned);
 gz::math::Quaterniond quatEnuToNed(const gz::math::Quaterniond& q_enu);

--- a/systems/physics_engine_interface/src/xdyn_websocket.cpp
+++ b/systems/physics_engine_interface/src/xdyn_websocket.cpp
@@ -11,14 +11,21 @@
 
 namespace lotusim::gazebo {
 
+// An attitude quaternion maps body axes to world axes, so converting it
+// between conventions changes BOTH frames: world swap (ENU<->NED) on the
+// left, body swap (FLU<->FRD) on the right. A similarity transform
+// (q_swap * q * q_swap^-1) only relabels the world frame and yields
+// yaw_ned = -yaw_enu instead of the correct yaw_ned = pi/2 - yaw_enu.
+// Both swap factors are 180-deg rotations (involutive up to sign), so the
+// same product converts in either direction.
 gz::math::Quaterniond quatNedToEnu(const gz::math::Quaterniond& q_ned)
 {
-    return q_ned_to_enu * q_ned * q_ned_to_enu.Inverse();
+    return q_ned_to_enu * q_ned * q_flu_to_frd;
 }
 
 gz::math::Quaterniond quatEnuToNed(const gz::math::Quaterniond& q_enu)
 {
-    return q_ned_to_enu.Inverse() * q_enu * q_ned_to_enu;
+    return q_ned_to_enu * q_enu * q_flu_to_frd;
 }
 
 gz::math::Vector3d vecNedToEnu(const gz::math::Vector3d& v_ned)


### PR DESCRIPTION
Closes #32.

## What

`quatNedToEnu`/`quatEnuToNed` used a world-frame-only similarity transform, mapping ENU yaw θ to NED yaw −θ. Converting an attitude quaternion between gz (ENU world, FLU body) and xdyn (NED world, FRD body) also changes the body convention, so a 180°-about-body-x factor is added: `q_ned_to_enu * q * q_flu_to_frd`, yielding the correct yaw_ned = π/2 − yaw_enu. The same product converts both directions (both factors are 180° rotations).

## Test

Plugin rebuilt and run on a focus_v2 close-hauled co-sim: the gz↔xdyn state round-trip is bit-identical per field, the boat holds the commanded 60° beat and completes a windward-leeward lap matching a direct-websocket xdyn reference within ~1.5 s over 160 s. Combined with #28 (independent fix in the same file) the attitude round-trip is exact.

---
*Assisted-by: Claude Fable 5 (claude-fable-5) via Claude Code.*