### PR TITLE
Fix(physics_engine_interface): send absolute sim time to xdyn, not step duration in ms

### DIFF
--- a/systems/physics_engine_interface/src/xdyn_websocket.cpp
+++ b/systems/physics_engine_interface/src/xdyn_websocket.cpp
@@ -313,7 +313,11 @@ XdynWebsocket::getNewState(
     data["Dt"] = time_diff / 1000.0;
     data["states"] = json::array();
     json previous_state_json = {
-        {"t", time_diff},
+        // Absolute sim time in seconds: xdyn uses states.back().t as the
+        // integration start time, and time-dependent forcings (waves) need the
+        // true clock. The raw step duration in ms sent here previously froze
+        // xdyn's clock at ~Dt, which is only harmless on calm water.
+        {"t", previous_state.time},
         {"x", ned_position.X()},
         {"y", ned_position.Y()},
         {"z", ned_position.Z()},


### PR DESCRIPTION
Closes #34.

## What

The co-sim request's `t` state field carried the raw gz step duration in milliseconds; xdyn uses `states.back().t` as the integration start time, freezing its clock at ~Dt and evaluating time-dependent forcings (waves) at a constant wrong time. The plugin already tracks absolute sim time in seconds (`previous_state.time`, from `_info.simTime`) — send that instead.

## Test

Websocket tap on a focus_v2 close-hauled run: `t` advances by the comm step in absolute seconds across 3708 frames; calm-water trajectories identical to before (t is inert without waves). Groundwork for enabling xdyn wave models through the gz stack.

---
*Assisted-by: Claude Fable 5 (claude-fable-5) via Claude Code.*