### PR TITLE
fix(physics_engine_interface): stop spurious warning and guard missing interface type

### DIFF
--- a/systems/physics_engine_interface/src/physics_interface_plugin.cpp
+++ b/systems/physics_engine_interface/src/physics_interface_plugin.cpp
@@ -290,13 +290,14 @@ void PhysicsInterfacePlugin::createDomainInterface(
     std::unordered_map<gz::sim::Entity, std::shared_ptr<PhysicsInterfaceBase>>&
         _interface_map)
 {
-    InterfaceType interface_type;
-    if (!_physics_sdf->HasElement("connection_type") ||
+    InterfaceType interface_type = InterfaceType::Unknown;
+    if (!_physics_sdf->HasElement("connection_type") &&
         !_physics_sdf->HasElement("interface_type")) {
-        m_logger->warn(
-            "PhysicsInterfacePlugin::createDomainInterface: {} missing {} interface_type or uri.",
+        m_logger->error(
+            "PhysicsInterfacePlugin::createDomainInterface: {} missing {} interface_type. Removing physics calculation.",
             _vessel_name,
             DomainTypeToStringMap[_domain]);
+        return;
     }
     try {
         // Temp support of legacy type connection_type, changing to


### PR DESCRIPTION
Closes #37.

## What

In `PhysicsInterfacePlugin::createDomainInterface`:

- warn only when **neither** `connection_type` (legacy) nor `interface_type` is set (`&&` instead of `||`) — the two are alternatives, so the previous condition fired for every correctly configured vessel in every world (reproducible with `assets/worlds/xdyn_multithread_test.world`);
- when neither is set, log an **error and return** instead of warning and continuing — previously `interface_type` stayed uninitialized and the indeterminate value was passed to `PhysicsInterfaceBase::createInterface()` (UB; a stack value of 0/1 silently selects the wrong interface). The pre-#36 code was safe by construction because `ConnectionTypeMap.at(...)` ran unconditionally and threw on the empty-string lookup; the `if / else if` introduced with the merge removed that net;
- initialize the enum to `InterfaceType::Unknown` as a belt-and-braces default (same value the `catch` below assigns);
- drop `uri` from the message — this function never checks it (`XdynWebsocket::configureInterface` does).

Behaviour for all correctly configured vessels is unchanged; they just stop logging a spurious warning.

## Verification

Package builds cleanly in the Docker environment:

```
$ colcon build --packages-select physics_engine_interface --merge-install
Starting >>> physics_engine_interface
Finished <<< physics_engine_interface [37.2s]
Summary: 1 package finished [37.4s]
```

No unit test added: `createDomainInterface` is a private member of the plugin and exercising the guard would require instantiating the plugin with an ECM and SDF fixtures — out of proportion for this change. Happy to add one if you'd prefer the method made testable.


---

*Assisted-by: Claude Fable 5 (claude-fable-5) via Claude Code — analysis, fix and this PR were AI-assisted, under human review; the commit carries the same trailer.*
