### PR TITLE
Feature(physics_engine_interface): seed angle-commanded control surfaces

### DIFF
--- a/systems/physics_engine_interface/src/xdyn_websocket.cpp
+++ b/systems/physics_engine_interface/src/xdyn_websocket.cpp
@@ -123,18 +123,43 @@ bool XdynWebsocket::configureInterface(
     }
     m_uri[_entity][domain_type] = uri;
 
-    if (_sdf->HasElement("thrusters") && m_models_cmd_map_ptr) {
-        auto sdfPtr_thruster = _sdf->GetElement("thrusters")->GetFirstElement();
-        auto thrusters_cmd = json::object();
-        do {
-            std::string thruster_name = sdfPtr_thruster->Get<std::string>();
-            thrusters_cmd[thruster_name + "(rpm)"] =
-                50.0;  // was 2.0 but crashes the Wageningen propeller
-            thrusters_cmd[thruster_name + "(P/D)"] = 0.79;
-            thrusters_cmd[thruster_name + "(beta)"] = 0.0;
-            sdfPtr_thruster = sdfPtr_thruster->GetNextElement();
-        } while (sdfPtr_thruster != sdf::ElementPtr(nullptr));
-        (*m_models_cmd_map_ptr)[_entity] = thrusters_cmd.dump();
+    if (m_models_cmd_map_ptr) {
+        auto initial_cmd = json::object();
+
+        // Propellers: each <thrusters> entry seeds its rpm/pitch/beta signals.
+        if (_sdf->HasElement("thrusters")) {
+            auto sdfPtr_thruster =
+                _sdf->GetElement("thrusters")->GetFirstElement();
+            do {
+                std::string thruster_name = sdfPtr_thruster->Get<std::string>();
+                initial_cmd[thruster_name + "(rpm)"] =
+                    50.0;  // was 2.0 but crashes the Wageningen propeller
+                initial_cmd[thruster_name + "(P/D)"] = 0.79;
+                initial_cmd[thruster_name + "(beta)"] = 0.0;
+                sdfPtr_thruster = sdfPtr_thruster->GetNextElement();
+            } while (sdfPtr_thruster != sdf::ElementPtr(nullptr));
+        }
+
+        // Angle-commanded actuators (rudders, sails, fins): each
+        // <control_surfaces> entry is the full xdyn command signal,
+        // e.g. "rudder(angle)" or "mainsail(sheet)", seeded to 0.0 so that
+        // commands.at(<signal>) does not throw before the first ROS setpoint.
+        // The default seeding from <thrusters> only does not cover these, so a
+        // vessel driven solely by control surfaces would otherwise crash the
+        // co-simulation on its first step.
+        if (_sdf->HasElement("control_surfaces")) {
+            auto sdfPtr_surface =
+                _sdf->GetElement("control_surfaces")->GetFirstElement();
+            do {
+                std::string signal = sdfPtr_surface->Get<std::string>();
+                initial_cmd[signal] = 0.0;
+                sdfPtr_surface = sdfPtr_surface->GetNextElement();
+            } while (sdfPtr_surface != sdf::ElementPtr(nullptr));
+        }
+
+        if (!initial_cmd.empty()) {
+            (*m_models_cmd_map_ptr)[_entity] = initial_cmd.dump();
+        }
     }
     return true;
 }


### PR DESCRIPTION
Closes #31.

## What

`XdynWebsocket::configureInterface` builds the initial command map only from `<thrusters>`, so a vessel driven by angle-commanded actuators (rudder, sail, fins) with no propeller spawns with an empty command map, and xdyn throws `commands.at(<signal>)` on the first co-simulation step (see #31 for the repro and stack trace).

This parses an optional `<control_surfaces>` block alongside `<thrusters>`: each entry is the full xdyn command signal (e.g. `rudder(angle)`, `mainsail(sheet)`), seeded to `0.0` so the co-sim starts cleanly before the first ROS setpoint arrives.

```xml
<control_surfaces>
  <sail>mainsail(sheet)</sail>
  <rudder>rudder(helm)</rudder>
</control_surfaces>
```

Thruster-only vessels are unaffected — the `<thrusters>` seeding is unchanged, including the `50.0` rpm default that came in with #36 (the "was 2.0 but crashes the Wageningen propeller" fix is preserved).

## Verification

- `physics_engine_interface` builds cleanly in the Docker environment (full `colcon build --merge-install` of the workspace on top of current `main`).
- Exercised end-to-end today with a sail-only vessel (no `<thrusters>`, only `<control_surfaces>`): the vessel spawns, the co-sim runs at RTF ≈ 1, and the boat sails a full windward/leeward lap (headless gz pose-oracle gate + Unity-rendered run). Without this patch the same world crashes xdyn on the first step, as described in #31.

---

*Assisted-by: Claude (Opus 4.8) via Claude Code — under human review; the commit carries `Signed-off-by` and `Assisted-by` trailers.*
