### PR TITLE
Feature(launch): let --assets-path add assets roots to the core one

### DIFF
--- a/launch/bash_completion.sh
+++ b/launch/bash_completion.sh
@@ -40,7 +40,20 @@ lotusim_script_completion() {
     fi
 
     if [[ -n "$cmd" ]]; then
-        local worlds=$(find ${LOTUSIM_PATH}/assets/worlds -type f -name '*.world' 2>/dev/null | sed "s|${LOTUSIM_PATH}/assets/worlds/||")
+        # Mirror how the launcher resolves worlds: the core assets root, plus
+        # any --assets-path already typed on this command line.
+        local roots=("${LOTUSIM_PATH}/assets") extra_roots i
+        for ((i = 0; i < ${#COMP_WORDS[@]} - 1; i++)); do
+            if [[ "${COMP_WORDS[i]}" == "--assets-path" ]]; then
+                IFS=':' read -ra extra_roots <<< "${COMP_WORDS[i + 1]}"
+                roots+=("${extra_roots[@]}")
+            fi
+        done
+
+        local worlds="" root
+        for root in "${roots[@]}"; do
+            worlds+=" $(find "${root}/worlds" -type f -name '*.world' 2>/dev/null | sed "s|${root}/worlds/||")"
+        done
         COMPREPLY=($(compgen -W "${worlds}" -- ${cur}))
         return 0
     fi

--- a/launch/bash_completion.sh
+++ b/launch/bash_completion.sh
@@ -9,6 +9,7 @@
 ##
 lotusim_script_completion() {
     local cur prev opts commands
+    COMP_WORDBREAKS=${COMP_WORDBREAKS//:/}
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD - 1]}"
 

--- a/launch/lotusim
+++ b/launch/lotusim
@@ -5,9 +5,10 @@ GREEN='\033[0;32m'
 YELLOW='\033[0;33m'
 NC='\033[0m' # No Color
 
-ASSETS_PATH="${LOTUSIM_PATH}/assets"
-MODEL_PATH="${ASSETS_PATH}/models"
-WORLD_PATH="${ASSETS_PATH}/worlds"
+# Assets roots, searched in order. The core one is always first; --assets-path
+# adds to it, so a consumer project composes its own models and worlds with the
+# core catalogue instead of having to choose between them.
+ASSETS_PATHS=("${LOTUSIM_PATH}/assets")
 BACKEND_DIR="${LOTUSIM_WS}/src/LOTUSim-UI-backend"
 FRONTEND_DIR="${LOTUSIM_WS}/src/LOTUSim-UI-frontend"
 
@@ -39,7 +40,10 @@ print_help() {
     echo -e "${GREEN}Usage:${NC} lotusim [OPTIONS] <command> [arguments]"
     echo -e "${GREEN}Options (can be placed anywhere):${NC}"
     echo -e "  --ws-path PATH          Path to the lotusim workspace (default: $LOTUSIM_WS)"
-    echo -e "  --assets-path PATH      Path to the assets directory (default: $ASSETS_PATH)"
+    echo -e "  --assets-path PATH[:PATH...]"
+    echo -e "                          Extra assets directories, searched after the core"
+    echo -e "                          one (${ASSETS_PATHS[0]}). Colon-separated and"
+    echo -e "                          repeatable; both forms append."
     echo -e "  --debug                 Enable debug mode"
     echo -e "  --gui                   Run gz sim GUI (for run command)"
     echo -e "  --help                  Display this help message"
@@ -78,9 +82,10 @@ parse_all_arguments() {
                 echo -e "${RED}Error:${NC} --assets-path requires a path argument"
                 exit 1
             fi
-            ASSETS_PATH="$2"
-            MODEL_PATH="${ASSETS_PATH}/models"
-            WORLD_PATH="${ASSETS_PATH}/worlds"
+            # Colon-separated like GZ_SIM_RESOURCE_PATH, which this feeds; the
+            # option is also repeatable. Both forms simply append.
+            IFS=':' read -ra extra_assets_paths <<< "$2"
+            ASSETS_PATHS+=("${extra_assets_paths[@]}")
             shift 2
             ;;
         --debug)
@@ -306,13 +311,34 @@ validate_ui_setup() {
 }
 
 
+# Colon-joined model roots, in search order: GZ_SIM_RESOURCE_PATH is a list.
+model_search_path() {
+    local path joined=""
+    for path in "${ASSETS_PATHS[@]}"; do
+        joined="${joined:+${joined}:}${path}/models"
+    done
+    printf '%s' "$joined"
+}
+
+# Print the first assets root that actually holds the requested world file.
+resolve_world_file() {
+    local world_file="$1" path
+    for path in "${ASSETS_PATHS[@]}"; do
+        if [[ -f "${path}/worlds/${world_file}" ]]; then
+            printf '%s' "${path}/worlds/${world_file}"
+            return 0
+        fi
+    done
+    return 1
+}
+
 source_environment() {
     source "/opt/ros/$ROS_DISTRO/setup.bash"
     source "${LOTUSIM_WS}/install/setup.bash"
 
     export GZ_SIM_SYSTEM_PLUGIN_PATH="${LOTUSIM_WS}/install/lib"
     export GZ_GUI_PLUGIN_PATH="${LOTUSIM_WS}/install/lib"
-    export GZ_SIM_RESOURCE_PATH="${MODEL_PATH}"
+    export GZ_SIM_RESOURCE_PATH="$(model_search_path)"
     export LOTUSIM_SPDLOG_LEVEL="${LOTUSIM_SPDLOG_LEVEL}"
 
     echo -e "${GREEN}GZ_SIM_SYSTEM_PLUGIN_PATH${NC}: $GZ_SIM_SYSTEM_PLUGIN_PATH"
@@ -372,9 +398,14 @@ run_command() {
 
         # Use provided world or default
         local world_file="${WORLD:-$DEFAULT_WORLD}"
+        local world_path
+        if ! world_path="$(resolve_world_file "$world_file")"; then
+            echo -e "${RED}Error:${NC} World '${world_file}' not found in: ${ASSETS_PATHS[*]}" >&2
+            exit 1
+        fi
 
-        echo -e "${GREEN}Running the simulation world${NC}: ${WORLD_PATH}/${world_file}"
-        gz sim ${DEBUG} ${GUI} -r "${WORLD_PATH}/${world_file}"
+        echo -e "${GREEN}Running the simulation world${NC}: ${world_path}"
+        gz sim ${DEBUG} ${GUI} -r "${world_path}"
         ;;
     ui)
         clear

--- a/launch/tests/test_assets_path.sh
+++ b/launch/tests/test_assets_path.sh
@@ -1,0 +1,139 @@
+#!/bin/bash
+# Checks that --assets-path adds assets roots to the core one rather than
+# replacing it, accepts a colon-separated list, is repeatable, and that a world
+# is resolved from whichever root holds it.
+#
+# Requires a built LOTUSim environment (LOTUSIM_WS/LOTUSIM_PATH set, gz available),
+# i.e. run it inside the LOTUSim image or after `lotusim install`:
+#
+#     bash launch/tests/test_assets_path.sh
+#
+# Creates its own throwaway assets roots; touches nothing in the workspace.
+
+LOTUSIM="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/lotusim"
+FIXTURE="$(mktemp -d)"
+trap 'rm -rf "$FIXTURE"' EXIT
+
+A="${FIXTURE}/rootA"
+B="${FIXTURE}/rootB"
+CORE="${LOTUSIM_PATH}/assets/models"
+mkdir -p "${A}/models/alpha" "${B}/worlds"
+
+cat > "${A}/models/alpha/model.config" <<'EOF'
+<?xml version="1.0"?>
+<model>
+  <name>alpha</name>
+  <version>1.0</version>
+  <sdf version="1.6">model.sdf</sdf>
+</model>
+EOF
+
+cat > "${A}/models/alpha/model.sdf" <<'EOF'
+<?xml version="1.0"?>
+<sdf version="1.6">
+  <model name="alpha">
+    <static>true</static>
+    <link name="link">
+      <visual name="v">
+        <geometry><box><size>1 1 1</size></box></geometry>
+      </visual>
+    </link>
+  </model>
+</sdf>
+EOF
+
+# The world lives in rootB but includes a model from rootA: it only loads when
+# both roots are searched.
+cat > "${B}/worlds/compose_test.world" <<'EOF'
+<?xml version="1.0"?>
+<sdf version="1.6">
+  <world name="compose_test">
+    <include><uri>model://alpha</uri></include>
+  </world>
+</sdf>
+EOF
+
+pass=0
+fail=0
+check() { # check <name> <expected-regex> <output>
+    if grep -Eq "$2" <<<"$3"; then
+        echo "  PASS  $1"
+        pass=$((pass + 1))
+    else
+        echo "  FAIL  $1"
+        echo "        expected /$2/"
+        echo "        got:     $(grep -a GZ_SIM_RESOURCE_PATH <<<"$3" | head -1)"
+        fail=$((fail + 1))
+    fi
+}
+
+echo "1. no option: the core assets root, unchanged"
+out=$("$LOTUSIM" run __no_such__.world 2>&1)
+check "GZ_SIM_RESOURCE_PATH is the core models dir" \
+    "GZ_SIM_RESOURCE_PATH.*: ${CORE}\$" "$out"
+
+echo "2. one option: added after the core root, which stays implicit"
+out=$("$LOTUSIM" --assets-path "$A" run __no_such__.world 2>&1)
+check "GZ_SIM_RESOURCE_PATH is core then rootA" \
+    "GZ_SIM_RESOURCE_PATH.*: ${CORE}:${A}/models\$" "$out"
+
+echo "3. one option, colon-separated"
+out=$("$LOTUSIM" --assets-path "${A}:${B}" run __no_such__.world 2>&1)
+check "GZ_SIM_RESOURCE_PATH is core then rootA then rootB" \
+    "GZ_SIM_RESOURCE_PATH.*: ${CORE}:${A}/models:${B}/models\$" "$out"
+
+echo "4. repeated option: same result as the colon-separated form"
+out=$("$LOTUSIM" --assets-path "$A" --assets-path "$B" run __no_such__.world 2>&1)
+check "GZ_SIM_RESOURCE_PATH is core then rootA then rootB" \
+    "GZ_SIM_RESOURCE_PATH.*: ${CORE}:${A}/models:${B}/models\$" "$out"
+check "a missing world names every searched root" \
+    "World '__no_such__.world' not found in: ${LOTUSIM_PATH}/assets ${A} ${B}" "$out"
+
+echo "5. the world is resolved from the root that holds it"
+out=$(timeout -s KILL 20 "$LOTUSIM" --assets-path "${A}:${B}" \
+    run compose_test.world 2>&1)
+check "world found under rootB" \
+    "Running the simulation world.*: ${B}/worlds/compose_test.world" "$out"
+
+echo "6. gz A/B: rootA's model resolves from rootB's world"
+# --debug (-v4) is required: at the default -v0 gz reports nothing and the A/B
+# would prove nothing.
+both=$(timeout -s KILL 20 "$LOTUSIM" --debug --assets-path "${A}:${B}" \
+    run compose_test.world 2>&1)
+only=$(timeout -s KILL 20 "$LOTUSIM" --debug --assets-path "$B" \
+    run compose_test.world 2>&1)
+
+if grep -aqi "unable to find uri\[model://alpha\]" <<<"$both"; then
+    echo "  FAIL  with both roots, gz cannot resolve model://alpha"
+    fail=$((fail + 1))
+else
+    echo "  PASS  with both roots, gz resolves model://alpha"
+    pass=$((pass + 1))
+fi
+
+if grep -aqi "unable to find uri\[model://alpha\]" <<<"$only"; then
+    echo "  PASS  without rootA, gz fails: composition is what makes the difference"
+    pass=$((pass + 1))
+else
+    echo "  FAIL  without rootA, gz should have failed; test 6 proves nothing"
+    fail=$((fail + 1))
+fi
+
+echo "7. completion offers worlds from the extra roots too"
+# shellcheck source=/dev/null
+source "$(dirname "$LOTUSIM")/bash_completion.sh"
+COMP_WORDS=(lotusim --assets-path "$B" run "")
+COMP_CWORD=4
+COMPREPLY=()
+lotusim_script_completion
+if printf '%s\n' "${COMPREPLY[@]}" | grep -qx "compose_test.world"; then
+    echo "  PASS  rootB's world is completed"
+    pass=$((pass + 1))
+else
+    echo "  FAIL  rootB's world missing from completion: ${COMPREPLY[*]}"
+    fail=$((fail + 1))
+fi
+
+echo
+echo "===== ${pass} passed / ${fail} failed ====="
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
Closes #46.

## What

`--assets-path` now **adds** an assets root instead of replacing the core one, so a
project that consumes LOTUSim can keep its own worlds and models in its own
repository and still run them through `lotusim run`:

```bash
lotusim --assets-path /my/scenario/assets run my_scenario.world
```

The core catalogue stays available — the sailboat from `assets/models` and the buoy
from the scenario resolve in the same world.

## Details

- The core root is always searched first; `--assets-path` appends after it.
- The option accepts a colon-separated list (`--assets-path "$A:$B"`) and is
  repeatable (`--assets-path $A --assets-path $B`). Both forms are equivalent — the
  colon form mirrors the `GZ_SIM_RESOURCE_PATH` this feeds.
- Worlds are resolved from whichever root holds them.
- A missing world now names every root searched, instead of being handed to gz and
  failing there with a less obvious message.
- Shell completion follows the same roots, so worlds outside the core are offered.

## Behaviour change, stated plainly

A single `--assets-path` used to **replace** the core root; it now **adds** to it.

We looked for callers before changing this: the option appears nowhere in this
repository, its CI, its documentation, the wiki, or LOTUSim-generic-scenario — only
in the completion script's option list. The replacing semantics were also the direct
cause of the limitation in #46. If you would rather keep them untouched, we are happy
to move the additive behaviour behind a separate flag.

There is no longer a way to exclude the core root. Nobody asked for that isolation and
an extra search entry is harmless, so we did not invent a flag for it.

## Verification

`launch/tests/test_assets_path.sh` is self-contained: it builds two throwaway assets
roots under `mktemp -d`, touches nothing in the workspace, and needs only a built
LOTUSim environment.

```
bash launch/tests/test_assets_path.sh
===== 9 passed / 0 failed =====
```

It covers the unchanged default, the additive single option, both multi-root forms and
their equivalence, world resolution from the owning root, the error message, and
completion. The decisive case is an A/B on gz itself: a world in root B that includes
`model://alpha` from root A loads with both roots and fails with
`Unable to find uri[model://alpha]` without root A — so the test would notice if the
composition silently stopped working.

Note for anyone reproducing it: the check needs `--debug`, because at the default
`-v0` gz reports nothing and the A/B would prove nothing.

Run against `ghcr.io/naval-group/lotusim` (Jazzy / Harmonic, `noble`).

## Not included

The wiki lives in its own repository, so the `--assets-path` entry in Getting-Started
is not part of this PR. Happy to send that separately if useful.

---

*Assisted-by: Claude Opus 5 (claude-opus-5) via Claude Code.*
