### PR TITLE
Integrate physic updates for xdyn interface 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,23 @@ jobs:
         with:
           context: .
           push: false
+          load: true
           build-args: |
             ROS_DISTRO=${{ matrix.ros }}
           tags: lotusim:${{ matrix.ros }}
+
+      # Advisory: runs the unit tests but does not gate the build while the
+      # project has no established test culture. Promote to a required check
+      # once test coverage is expected on logic PRs.
+      - name: Unit tests (advisory)
+        continue-on-error: true
+        run: |
+          docker run --rm lotusim:${{ matrix.ros }} bash -c '
+            source /opt/ros/${{ matrix.ros }}/setup.bash &&
+            source "$LOTUSIM_WS/install/setup.bash" &&
+            cd "$LOTUSIM_WS" &&
+            colcon build --packages-select physics_engine_interface \
+              --merge-install --cmake-args -DBUILD_TESTING=ON &&
+            colcon test --packages-select physics_engine_interface \
+              --merge-install --event-handlers console_direct+ &&
+            colcon test-result --verbose'

--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,31 @@
+Cédric Buche <cedric.buche@pacific.naval-group.com>
+
+Cyril Moron <cyril.moron@gmail.com>
+
+Estelle Chauveau <estelle.chauveau@naval-group.com>
+
+Esther Rayssiguie <esther.rayssiguie@fe.naval-group.com> <77739079+estherRay@users.noreply.github.com>
+Esther Rayssiguie <esther.rayssiguie@fe.naval-group.com> <erayssiguie.exterieur@naval-group.com>
+Esther Rayssiguie <esther.rayssiguie@fe.naval-group.com> <newsther@yahoo.com>
+
+Guillaume Jacquenot <guillaume.jacquenot@gmail.com> <Gjacquenot@users.noreply.github.com>
+Guillaume Jacquenot <guillaume.jacquenot@gmail.com> <guillaume.jacquenot@sirehna.com>
+
+Hélène Lechêne <hlechene.exterieur@pacific.naval-group.com>
+
+Julien Prodhon <julien.prodhon@fe.naval-group.com>
+
+Juliette Grosset <jgrosset10@gmail.com> <jgrosset.external@pacific.naval-group.com>
+Juliette Grosset <jgrosset10@gmail.com> <60522207+grossetjuliette@users.noreply.github.com>
+
+Kerian Fiter <kerian.fiter@gmail.com> <kfiter.exterieur@pacific.naval-group.com>
+
+Malcom Neo <malcom.neo@fe.naval-group.com> <51524465+malcom-neo@users.noreply.github.com>
+Malcom Neo <malcom.neo@fe.naval-group.com> <malcom.neo@gmail.com>
+Malcom Neo <malcom.neo@fe.naval-group.com> <malcomneo@gmail.com>
+
+Paul Mellin <paul.mellin@naval-group.com>
+
+Quentin Arzel <qarzel.exterieur@pacific.naval-group.com>
+
+Raphaël Clément <raphael.clement@naval-group.com> <clement_raphael@orange.fr>

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -11,8 +11,4 @@ Diversity is one of our huge strengths, but it can also lead to communication is
 - **Be careful in the words that you choose.** We are a community of professionals, and we conduct ourselves professionally. Be kind to others. Do not insult or put down other participants. Harassment and other exclusionary behavior aren't acceptable. Treat others like you want to be treated.
 - **When we disagree, try to understand why.** Disagreements, both social and technical, happen all the time and LOTUSim is no exception. It is important that we resolve disagreements and differing views constructively. Remember that we're different. The strength of LOTUSim comes from its varied community, people from a wide range of backgrounds. Different people have different perspectives on issues. Being unable to understand why someone holds a viewpoint doesn't mean that they're wrong. Don't forget that blaming each other doesn't get us anywhere. Instead, focus on helping to resolve issues and learning from mistakes.
 
-<<<<<<< HEAD
 Original text courtesy of the [Django](https://www.djangoproject.com/conduct/) project.
-=======
-Original text courtesy of the [Django](https://www.djangoproject.com/conduct/) project.
->>>>>>> a712a4b (Create CODE_OF_CONDUCT.md)

--- a/assets/worlds/aerialWorld.world
+++ b/assets/worlds/aerialWorld.world
@@ -33,7 +33,9 @@
 
     <plugin filename="gz-sim-physics-system" name="gz::sim::systems::Physics" />
 
-    <plugin filename="aerial_demo_mas" name="lotusim::gazebo::AerialMAS" />
+    <plugin filename="aerial_demo_mas" name="lotusim::gazebo::AerialMAS">
+            <aerial_namespace>aerialWorld</aerial_namespace>
+    </plugin>
     <plugin filename="gz-sim-scene-broadcaster-system" name="gz::sim::systems::SceneBroadcaster" />
 
     <!-- Wind Plugin -->

--- a/docs/frames_check.py
+++ b/docs/frames_check.py
@@ -136,9 +136,9 @@ class VehicleState:
         # Quaternion frame change: q_new = q_R ⊗ q ⊗ q_R*
         q = (self.qr, self.qi, self.qj, self.qk)
         # new_q_tuple = quat_mult(quat_mult(Q_R, q), Q_R_CONJ)
-        # new_q_tuple = quat_mult(quat_mult(Q_R, q), Q_FLU_FRD)
+        new_q_tuple = quat_mult(quat_mult(Q_R, q), Q_FLU_FRD)
         
-        new_q_tuple = quat_mult(Q_R, q)
+        # new_q_tuple = quat_mult(Q_R, q)
         new_qr, new_qi, new_qj, new_qk = normalize_quat(new_q_tuple)
 
         new_convention = Convention.NED if self.convention == Convention.ENU else Convention.ENU
@@ -163,6 +163,28 @@ class VehicleState:
             f"  Euler (deg)   : phi={self.phi*180/math.pi:.4f}, theta={self.theta*180/math.pi:.4f}, psi={self.psi*180/math.pi:.4f}\n"
         )
 
+    def __eq__(self, other: object) -> bool:
+        """Compare two VehicleState instances for equality within a numerical tolerance."""
+        if not isinstance(other, VehicleState):
+            return NotImplemented
+        if self.convention != other.convention:
+            return False
+        tol = 1e-6
+        return all(abs(a - b) < tol for a, b in [
+            (self.x,  other.x),
+            (self.y,  other.y),
+            (self.z,  other.z),
+            (self.u,  other.u),
+            (self.v,  other.v),
+            (self.w,  other.w),
+            (self.p,  other.p),
+            (self.q,  other.q),
+            (self.r,  other.r),
+            (self.qr, other.qr),
+            (self.qi, other.qi),
+            (self.qj, other.qj),
+            (self.qk, other.qk),
+        ])
 
 def demo00():
     ned_state = VehicleState(
@@ -200,4 +222,4 @@ def demo01():
 
 if __name__ == "__main__":
     demo00()
-    demo01()
+    # demo01()

--- a/docs/frames_check.py
+++ b/docs/frames_check.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from enum import Enum
 import math
+import random
 
 
 class Convention(Enum):
@@ -32,6 +33,35 @@ def normalize_quat(q):
     if qr < 0:
         qr, qi, qj, qk = -qr, -qi, -qj, -qk
     return qr, qi, qj, qk
+
+def quat_from_rot_x(angle: float) -> tuple:
+    """Quaternion for a rotation of `angle` (rad) about the X axis."""
+    return (
+        math.cos(angle / 2),
+        math.sin(angle / 2),
+        0.0,
+        0.0,
+    )
+
+
+def quat_from_rot_y(angle: float) -> tuple:
+    """Quaternion for a rotation of `angle` (rad) about the Y axis."""
+    return (
+        math.cos(angle / 2),
+        0.0,
+        math.sin(angle / 2),
+        0.0,
+    )
+
+
+def quat_from_rot_z(angle: float) -> tuple:
+    """Quaternion for a rotation of `angle` (rad) about the Z axis."""
+    return (
+        math.cos(angle / 2),
+        0.0,
+        0.0,
+        math.sin(angle / 2),
+    )
 
 
 # q_R: 180° rotation about (X+Y)/√2 axis — the ENU<->NED frame rotation
@@ -133,12 +163,11 @@ class VehicleState:
         new_q = -self.q
         new_r = -self.r
 
-        # Quaternion frame change: q_new = q_R ⊗ q ⊗ q_R*
+        # Quaternion frame change
         q = (self.qr, self.qi, self.qj, self.qk)
-        # new_q_tuple = quat_mult(quat_mult(Q_R, q), Q_R_CONJ)
         new_q_tuple = quat_mult(quat_mult(Q_R, q), Q_FLU_FRD)
         
-        # new_q_tuple = quat_mult(Q_R, q)
+        new_q_tuple = quat_mult(Q_R, q)
         new_qr, new_qi, new_qj, new_qk = normalize_quat(new_q_tuple)
 
         new_convention = Convention.NED if self.convention == Convention.ENU else Convention.ENU
@@ -186,6 +215,42 @@ class VehicleState:
             (self.qk, other.qk),
         ])
 
+
+
+def random_vehicle_state(convention: Convention = Convention.ENU, seed: int = None) -> VehicleState:
+    """Generate a random VehicleState with realistic vehicle ranges."""
+    if seed is not None:
+        random.seed(seed)
+
+    def rand(lo, hi):
+        return random.uniform(lo, hi)
+
+    # Random Euler angles then build quaternion via ZYX composition
+    phi   = rand(-math.pi,      math.pi)       # roll   [-180°, 180°]
+    theta = rand(-math.pi / 2,  math.pi / 2)   # pitch  [ -90°,  90°]
+    psi   = rand(-math.pi,      math.pi)       # yaw    [-180°, 180°]
+
+    q = quat_mult(
+            quat_mult(quat_from_rot_z(psi), quat_from_rot_y(theta)),
+            quat_from_rot_x(phi)
+        )
+
+    return VehicleState(
+        convention=convention,
+        x = rand(-1000.0,  1000.0),   # m
+        y = rand(-1000.0,  1000.0),   # m
+        z = rand(    0.0,  1000.0),   # m  (positive up in ENU)
+        u = rand(  -50.0,    50.0),   # m/s
+        v = rand(  -10.0,    10.0),   # m/s
+        w = rand(   -5.0,     5.0),   # m/s
+        p = rand(-math.pi, math.pi),  # rad/s
+        q = rand(-math.pi, math.pi),  # rad/s
+        r = rand(-math.pi, math.pi),  # rad/s
+        qr=q[0], qi=q[1], qj=q[2], qk=q[3],
+    )
+
+
+
 def demo00():
     ned_state = VehicleState(
         convention=Convention.NED,
@@ -202,6 +267,7 @@ def demo00():
     print(enu_state)
     print("Round-trip back to NED:")
     print(ned_back)
+    print(ned_state == ned_back)
 
 def demo01():
     ned_state = VehicleState(
@@ -219,7 +285,23 @@ def demo01():
     print(enu_state)
     print("Round-trip back to NED:")
     print(ned_back)
+    print(ned_state == ned_back)
+
+
+
+def demo03():
+    state_enu = random_vehicle_state(Convention.ENU, seed=42)
+    state_ned = state_enu.convert()
+    assert abs(state_enu.z - (-state_ned.z)) < 1e-10 
+    assert abs(state_enu.x - (+state_ned.y)) < 1e-10 
+    assert abs(state_enu.y - (+state_ned.x)) < 1e-10 
+    assert abs(state_enu.z_dot - (-state_ned.z_dot)) < 1e-10 
+    assert abs(state_enu.x_dot - (+state_ned.y_dot)) < 1e-10 
+    assert abs(state_enu.y_dot - (+state_ned.x_dot)) < 1e-10 
 
 if __name__ == "__main__":
     demo00()
-    # demo01()
+    demo01()
+    demo03()
+    quat_ned2enu = quat_mult(quat_from_rot_z(math.pi/2), quat_from_rot_x(math.pi))
+    print(quat_ned2enu)

--- a/docs/frames_check.py
+++ b/docs/frames_check.py
@@ -1,0 +1,158 @@
+from dataclasses import dataclass
+from enum import Enum
+import math
+
+
+class Convention(Enum):
+    ENU = "ENU"
+    NED = "NED"
+
+
+def quat_mult(a, b):
+    """Hamilton product of two quaternions (wr,wi,wj,wk)."""
+    ar, ai, aj, ak = a
+    br, bi, bj, bk = b
+    return (
+        ar*br - ai*bi - aj*bj - ak*bk,
+        ar*bi + ai*br + aj*bk - ak*bj,
+        ar*bj - ai*bk + aj*br + ak*bi,
+        ar*bk + ai*bj - aj*bi + ak*br,
+    )
+
+
+def quat_conj(q):
+    qr, qi, qj, qk = q
+    return (qr, -qi, -qj, -qk)
+
+
+def normalize_quat(q):
+    qr, qi, qj, qk = q
+    norm = math.sqrt(qr**2 + qi**2 + qj**2 + qk**2)
+    qr, qi, qj, qk = qr/norm, qi/norm, qj/norm, qk/norm
+    if qr < 0:
+        qr, qi, qj, qk = -qr, -qi, -qj, -qk
+    return qr, qi, qj, qk
+
+
+# q_R: 180° rotation about (X+Y)/√2 axis — the ENU<->NED frame rotation
+# = (cos(90°), sin(90°)/√2, sin(90°)/√2, 0) = (0, 1/√2, 1/√2, 0)
+SQRT2_INV = 1.0 / math.sqrt(2.0)
+Q_R = (0.0, SQRT2_INV, SQRT2_INV, 0.0)
+Q_FLU_FRD = (0.0, 1.0, 0.0, 0.0)
+
+@dataclass
+class VehicleState:
+    convention: Convention
+
+    # Position
+    x: float = 0.0
+    y: float = 0.0
+    z: float = 0.0
+
+    # Linear velocities (body frame)
+    u: float = 0.0
+    v: float = 0.0
+    w: float = 0.0
+
+    # Angular velocities (body frame)
+    p: float = 0.0
+    q: float = 0.0
+    r: float = 0.0
+
+    # Quaternion (scalar-first: qr + qi*i + qj*j + qk*k)
+    qr: float = 1.0
+    qi: float = 0.0
+    qj: float = 0.0
+    qk: float = 0.0
+
+    def __post_init__(self):
+        self.qr, self.qi, self.qj, self.qk = normalize_quat(
+            (self.qr, self.qi, self.qj, self.qk)
+        )
+
+    @property
+    def phi(self) -> float:
+        """Roll (rad), ZYX convention."""
+        return math.atan2(
+            2.0 * (self.qr * self.qi + self.qj * self.qk),
+            1.0 - 2.0 * (self.qi**2 + self.qj**2)
+        )
+
+    @property
+    def theta(self) -> float:
+        """Pitch (rad), ZYX convention."""
+        sin_pitch = 2.0 * (self.qr * self.qj - self.qk * self.qi)
+        return math.asin(max(-1.0, min(1.0, sin_pitch)))
+
+    @property
+    def psi(self) -> float:
+        """Yaw (rad), ZYX convention."""
+        return math.atan2(
+            2.0 * (self.qr * self.qk + self.qi * self.qj),
+            1.0 - 2.0 * (self.qj**2 + self.qk**2)
+        )
+
+    def convert(self) -> "VehicleState":
+        """Return a new VehicleState with the opposite convention (ENU <-> NED)."""
+
+        # Position: x<->y swap, z flips
+        new_x = self.y
+        new_y = self.x
+        new_z = -self.z
+
+        # Body linear velocities: u unchanged, v and w flip
+        new_u = self.u
+        new_v = -self.v
+        new_w = -self.w
+
+        # Body angular velocities: p unchanged, q and r flip
+        new_p = self.p
+        new_q = -self.q
+        new_r = -self.r
+
+        # Quaternion frame change: q_new = q_R ⊗ q ⊗ q_R*
+        q = (self.qr, self.qi, self.qj, self.qk)
+        # new_q_tuple = quat_mult(quat_mult(Q_R, q), Q_R_CONJ)
+        # new_q_tuple = quat_mult(quat_mult(Q_R, q), Q_FLU_FRD)
+        
+        new_q_tuple = quat_mult(Q_R, q)
+        new_qr, new_qi, new_qj, new_qk = normalize_quat(new_q_tuple)
+
+        new_convention = Convention.NED if self.convention == Convention.ENU else Convention.ENU
+
+        return VehicleState(
+            convention=new_convention,
+            x=new_x, y=new_y, z=new_z,
+            u=new_u, v=new_v, w=new_w,
+            p=new_p, q=new_q, r=new_r,
+            qr=new_qr, qi=new_qi, qj=new_qj, qk=new_qk,
+        )
+
+    def __str__(self) -> str:
+        return (
+            f"VehicleState [{self.convention.value}]\n"
+            f"  Position      : x={self.x:.4f},  y={self.y:.4f},  z={self.z:.4f}\n"
+            f"  Lin. velocity : u={self.u:.4f},  v={self.v:.4f},  w={self.w:.4f}\n"
+            f"  Ang. velocity : p={self.p:.4f},  q={self.q:.4f},  r={self.r:.4f}\n"
+            f"  Quaternion    : qr={self.qr:.4f}, qi={self.qi:.4f}, qj={self.qj:.4f}, qk={self.qk:.4f}\n"
+            f"  Euler (rad)   : phi={self.phi:.4f}, theta={self.theta:.4f}, psi={self.psi:.4f}\n"
+            f"  Euler (deg)   : phi={self.phi*180/math.pi:.4f}, theta={self.theta*180/math.pi:.4f}, psi={self.psi*180/math.pi:.4f}\n"
+        )
+
+
+if __name__ == "__main__":
+    ned_state = VehicleState(
+        convention=Convention.NED,
+        x=1.0, y=2.0, z=3.0,
+        u=1.0, v=0.5, w=0.2,
+        p=0.1, q=0.05, r=0.02,
+        qr=math.cos(math.pi/6), qi=0.0, qj=0.0, qk=math.sin(math.pi/6),
+    )
+
+    enu_state = ned_state.convert()
+    ned_back  = enu_state.convert()
+
+    print(ned_state)
+    print(enu_state)
+    print("Round-trip back to NED:")
+    print(ned_back)

--- a/docs/frames_check.py
+++ b/docs/frames_check.py
@@ -92,6 +92,29 @@ class VehicleState:
             1.0 - 2.0 * (self.qj**2 + self.qk**2)
         )
 
+    @property
+    def x_dot(self) -> float:
+        """Fixed-frame velocity along X, derived from quaternion and body velocities."""
+        return self._body_to_fixed()[0]
+
+    @property
+    def y_dot(self) -> float:
+        """Fixed-frame velocity along Y, derived from quaternion and body velocities."""
+        return self._body_to_fixed()[1]
+
+    @property
+    def z_dot(self) -> float:
+        """Fixed-frame velocity along Z, derived from quaternion and body velocities."""
+        return self._body_to_fixed()[2]
+
+    def _body_to_fixed(self) -> tuple:
+        """Rotate body velocities (u,v,w) to fixed frame via q ⊗ v_body ⊗ q*."""
+        q = (self.qr, self.qi, self.qj, self.qk)
+        v_body = (0.0, self.u, self.v, self.w)  # pure quaternion
+        v_fixed = quat_mult(quat_mult(q, v_body), quat_conj(q))
+        # v_fixed is a pure quaternion: (0, x_dot, y_dot, z_dot)
+        return v_fixed[1], v_fixed[2], v_fixed[3]
+
     def convert(self) -> "VehicleState":
         """Return a new VehicleState with the opposite convention (ENU <-> NED)."""
 
@@ -133,6 +156,7 @@ class VehicleState:
             f"VehicleState [{self.convention.value}]\n"
             f"  Position      : x={self.x:.4f},  y={self.y:.4f},  z={self.z:.4f}\n"
             f"  Lin. velocity : u={self.u:.4f},  v={self.v:.4f},  w={self.w:.4f}\n"
+            f"  Fixed velocity: x_dot={self.x_dot:.4f}, y_dot={self.y_dot:.4f}, z_dot={self.z_dot:.4f}\n"
             f"  Ang. velocity : p={self.p:.4f},  q={self.q:.4f},  r={self.r:.4f}\n"
             f"  Quaternion    : qr={self.qr:.4f}, qi={self.qi:.4f}, qj={self.qj:.4f}, qk={self.qk:.4f}\n"
             f"  Euler (rad)   : phi={self.phi:.4f}, theta={self.theta:.4f}, psi={self.psi:.4f}\n"
@@ -140,7 +164,24 @@ class VehicleState:
         )
 
 
-if __name__ == "__main__":
+def demo00():
+    ned_state = VehicleState(
+        convention=Convention.NED,
+        x=1.0, y=2.0, z=3.0,
+        u=1.0, v=0.5, w=0.2,
+        p=0.1, q=0.05, r=0.02,
+        qr=1.0, qi=0.0, qj=0.0, qk=0.0,
+    )
+
+    enu_state = ned_state.convert()
+    ned_back  = enu_state.convert()
+
+    print(ned_state)
+    print(enu_state)
+    print("Round-trip back to NED:")
+    print(ned_back)
+
+def demo01():
     ned_state = VehicleState(
         convention=Convention.NED,
         x=1.0, y=2.0, z=3.0,
@@ -156,3 +197,7 @@ if __name__ == "__main__":
     print(enu_state)
     print("Round-trip back to NED:")
     print(ned_back)
+
+if __name__ == "__main__":
+    demo00()
+    demo01()

--- a/docs/frames_check.py
+++ b/docs/frames_check.py
@@ -1,7 +1,67 @@
-from dataclasses import dataclass
-from enum import Enum
+"""
+vehicle_state.py
+================
+Utility module for representing and converting vehicle kinematic states between
+the ENU (East-North-Up) and NED (North-East-Down) coordinate frames.
+
+Coordinate Frames
+-----------------
+ENU (East-North-Up):
+    x -> East
+    y -> North
+    z -> Up
+
+NED (North-East-Down):
+    x -> North
+    y -> East
+    z -> Down
+
+The ENU<->NED frame change is a 180° rotation about the (X+Y)/√2 axis,
+represented by the unit quaternion Q_R = (0, 1/√2, 1/√2, 0).
+
+State Variables
+---------------
+Position        : x, y, z         [m]         fixed frame
+Linear velocity : u, v, w         [m/s]       body frame
+Angular velocity: p, q, r         [rad/s]     body frame
+Attitude        : qr, qi, qj, qk  [-]         unit quaternion (scalar-first)
+Euler angles    : phi, theta, psi [rad]       derived from quaternion, ZYX convention
+
+ENU <-> NED Conversion Rules
+-----------------------------
+Position        : x_ned = y_enu,  y_ned = x_enu,  z_ned = -z_enu
+Linear velocity : u_ned = u_enu,  v_ned = -v_enu, w_ned = -w_enu
+Angular velocity: p_ned = p_enu,  q_ned = -q_enu, r_ned = -r_enu
+Quaternion      : q_ned = Q_R ⊗ q_enu   (Q_R is self-inverse)
+
+Quaternion Convention
+---------------------
+Scalar-first Hamilton convention: q = qr + qi*i + qj*j + qk*k
+Canonical form enforces qr >= 0 to avoid the q / -q ambiguity.
+Attitude quaternion encodes the rotation from body frame to fixed frame,
+so that fixed-frame vectors are obtained via: v_fixed = q ⊗ v_body ⊗ q*
+
+Contents
+--------
+Functions:
+    quat_mult(a, b)         Hamilton product of two quaternions
+    quat_conj(q)            Conjugate of a quaternion
+    normalize_quat(q)       Normalize to unit norm and canonical form (qr >= 0)
+    quat_from_rot_x(angle)  Quaternion for a rotation about X axis
+    quat_from_rot_y(angle)  Quaternion for a rotation about Y axis
+    quat_from_rot_z(angle)  Quaternion for a rotation about Z axis
+    random_vehicle_state()  Generate a random VehicleState
+
+Classes:
+    Convention              Enum for ENU / NED frame selection
+    VehicleState            Dataclass holding the full kinematic state
+
+"""
+
 import math
 import random
+from dataclasses import dataclass
+from enum import Enum
 
 
 class Convention(Enum):
@@ -14,10 +74,10 @@ def quat_mult(a, b):
     ar, ai, aj, ak = a
     br, bi, bj, bk = b
     return (
-        ar*br - ai*bi - aj*bj - ak*bk,
-        ar*bi + ai*br + aj*bk - ak*bj,
-        ar*bj - ai*bk + aj*br + ak*bi,
-        ar*bk + ai*bj - aj*bi + ak*br,
+        ar * br - ai * bi - aj * bj - ak * bk,
+        ar * bi + ai * br + aj * bk - ak * bj,
+        ar * bj - ai * bk + aj * br + ak * bi,
+        ar * bk + ai * bj - aj * bi + ak * br,
     )
 
 
@@ -29,10 +89,11 @@ def quat_conj(q):
 def normalize_quat(q):
     qr, qi, qj, qk = q
     norm = math.sqrt(qr**2 + qi**2 + qj**2 + qk**2)
-    qr, qi, qj, qk = qr/norm, qi/norm, qj/norm, qk/norm
+    qr, qi, qj, qk = qr / norm, qi / norm, qj / norm, qk / norm
     if qr < 0:
         qr, qi, qj, qk = -qr, -qi, -qj, -qk
     return qr, qi, qj, qk
+
 
 def quat_from_rot_x(angle: float) -> tuple:
     """Quaternion for a rotation of `angle` (rad) about the X axis."""
@@ -70,6 +131,7 @@ SQRT2_INV = 1.0 / math.sqrt(2.0)
 Q_R = (0.0, SQRT2_INV, SQRT2_INV, 0.0)
 Q_FLU_FRD = (0.0, 1.0, 0.0, 0.0)
 
+
 @dataclass
 class VehicleState:
     convention: Convention
@@ -105,7 +167,7 @@ class VehicleState:
         """Roll (rad), ZYX convention."""
         return math.atan2(
             2.0 * (self.qr * self.qi + self.qj * self.qk),
-            1.0 - 2.0 * (self.qi**2 + self.qj**2)
+            1.0 - 2.0 * (self.qi**2 + self.qj**2),
         )
 
     @property
@@ -119,7 +181,7 @@ class VehicleState:
         """Yaw (rad), ZYX convention."""
         return math.atan2(
             2.0 * (self.qr * self.qk + self.qi * self.qj),
-            1.0 - 2.0 * (self.qj**2 + self.qk**2)
+            1.0 - 2.0 * (self.qj**2 + self.qk**2),
         )
 
     @property
@@ -166,18 +228,30 @@ class VehicleState:
         # Quaternion frame change
         q = (self.qr, self.qi, self.qj, self.qk)
         new_q_tuple = quat_mult(quat_mult(Q_R, q), Q_FLU_FRD)
-        
-        new_q_tuple = quat_mult(Q_R, q)
+
+        # This is not sufficient to do this:
+        # new_q_tuple = quat_mult(Q_R, q)
         new_qr, new_qi, new_qj, new_qk = normalize_quat(new_q_tuple)
 
-        new_convention = Convention.NED if self.convention == Convention.ENU else Convention.ENU
+        new_convention = (
+            Convention.NED if self.convention == Convention.ENU else Convention.ENU
+        )
 
         return VehicleState(
             convention=new_convention,
-            x=new_x, y=new_y, z=new_z,
-            u=new_u, v=new_v, w=new_w,
-            p=new_p, q=new_q, r=new_r,
-            qr=new_qr, qi=new_qi, qj=new_qj, qk=new_qk,
+            x=new_x,
+            y=new_y,
+            z=new_z,
+            u=new_u,
+            v=new_v,
+            w=new_w,
+            p=new_p,
+            q=new_q,
+            r=new_r,
+            qr=new_qr,
+            qi=new_qi,
+            qj=new_qj,
+            qk=new_qk,
         )
 
     def __str__(self) -> str:
@@ -199,25 +273,29 @@ class VehicleState:
         if self.convention != other.convention:
             return False
         tol = 1e-6
-        return all(abs(a - b) < tol for a, b in [
-            (self.x,  other.x),
-            (self.y,  other.y),
-            (self.z,  other.z),
-            (self.u,  other.u),
-            (self.v,  other.v),
-            (self.w,  other.w),
-            (self.p,  other.p),
-            (self.q,  other.q),
-            (self.r,  other.r),
-            (self.qr, other.qr),
-            (self.qi, other.qi),
-            (self.qj, other.qj),
-            (self.qk, other.qk),
-        ])
+        return all(
+            abs(a - b) < tol
+            for a, b in [
+                (self.x, other.x),
+                (self.y, other.y),
+                (self.z, other.z),
+                (self.u, other.u),
+                (self.v, other.v),
+                (self.w, other.w),
+                (self.p, other.p),
+                (self.q, other.q),
+                (self.r, other.r),
+                (self.qr, other.qr),
+                (self.qi, other.qi),
+                (self.qj, other.qj),
+                (self.qk, other.qk),
+            ]
+        )
 
 
-
-def random_vehicle_state(convention: Convention = Convention.ENU, seed: int = None) -> VehicleState:
+def random_vehicle_state(
+    convention: Convention = Convention.ENU, seed: int = None
+) -> VehicleState:
     """Generate a random VehicleState with realistic vehicle ranges."""
     if seed is not None:
         random.seed(seed)
@@ -226,82 +304,102 @@ def random_vehicle_state(convention: Convention = Convention.ENU, seed: int = No
         return random.uniform(lo, hi)
 
     # Random Euler angles then build quaternion via ZYX composition
-    phi   = rand(-math.pi,      math.pi)       # roll   [-180°, 180°]
-    theta = rand(-math.pi / 2,  math.pi / 2)   # pitch  [ -90°,  90°]
-    psi   = rand(-math.pi,      math.pi)       # yaw    [-180°, 180°]
+    phi = rand(-math.pi, math.pi)  # roll   [-180°, 180°]
+    theta = rand(-math.pi / 2, math.pi / 2)  # pitch  [ -90°,  90°]
+    psi = rand(-math.pi, math.pi)  # yaw    [-180°, 180°]
 
     q = quat_mult(
-            quat_mult(quat_from_rot_z(psi), quat_from_rot_y(theta)),
-            quat_from_rot_x(phi)
-        )
+        quat_mult(quat_from_rot_z(psi), quat_from_rot_y(theta)), quat_from_rot_x(phi)
+    )
 
     return VehicleState(
         convention=convention,
-        x = rand(-1000.0,  1000.0),   # m
-        y = rand(-1000.0,  1000.0),   # m
-        z = rand(    0.0,  1000.0),   # m  (positive up in ENU)
-        u = rand(  -50.0,    50.0),   # m/s
-        v = rand(  -10.0,    10.0),   # m/s
-        w = rand(   -5.0,     5.0),   # m/s
-        p = rand(-math.pi, math.pi),  # rad/s
-        q = rand(-math.pi, math.pi),  # rad/s
-        r = rand(-math.pi, math.pi),  # rad/s
-        qr=q[0], qi=q[1], qj=q[2], qk=q[3],
+        x=rand(-1000.0, 1000.0),  # m
+        y=rand(-1000.0, 1000.0),  # m
+        z=rand(0.0, 1000.0),  # m  (positive up in ENU)
+        u=rand(-50.0, 50.0),  # m/s
+        v=rand(-10.0, 10.0),  # m/s
+        w=rand(-5.0, 5.0),  # m/s
+        p=rand(-math.pi, math.pi),  # rad/s
+        q=rand(-math.pi, math.pi),  # rad/s
+        r=rand(-math.pi, math.pi),  # rad/s
+        qr=q[0],
+        qi=q[1],
+        qj=q[2],
+        qk=q[3],
     )
-
 
 
 def demo00():
     ned_state = VehicleState(
         convention=Convention.NED,
-        x=1.0, y=2.0, z=3.0,
-        u=1.0, v=0.5, w=0.2,
-        p=0.1, q=0.05, r=0.02,
-        qr=1.0, qi=0.0, qj=0.0, qk=0.0,
+        x=1.0,
+        y=2.0,
+        z=3.0,
+        u=1.0,
+        v=0.5,
+        w=0.2,
+        p=0.1,
+        q=0.05,
+        r=0.02,
+        qr=1.0,
+        qi=0.0,
+        qj=0.0,
+        qk=0.0,
     )
 
     enu_state = ned_state.convert()
-    ned_back  = enu_state.convert()
+    ned_back = enu_state.convert()
 
     print(ned_state)
     print(enu_state)
     print("Round-trip back to NED:")
     print(ned_back)
     print(ned_state == ned_back)
+
 
 def demo01():
     ned_state = VehicleState(
         convention=Convention.NED,
-        x=1.0, y=2.0, z=3.0,
-        u=1.0, v=0.5, w=0.2,
-        p=0.1, q=0.05, r=0.02,
-        qr=math.cos(math.pi/6), qi=0.0, qj=0.0, qk=math.sin(math.pi/6),
+        x=1.0,
+        y=2.0,
+        z=3.0,
+        u=1.0,
+        v=0.5,
+        w=0.2,
+        p=0.1,
+        q=0.05,
+        r=0.02,
+        qr=math.cos(math.pi / 6),
+        qi=0.0,
+        qj=0.0,
+        qk=math.sin(math.pi / 6),
     )
 
     enu_state = ned_state.convert()
-    ned_back  = enu_state.convert()
+    ned_back = enu_state.convert()
 
     print(ned_state)
     print(enu_state)
     print("Round-trip back to NED:")
     print(ned_back)
     print(ned_state == ned_back)
-
 
 
 def demo03():
     state_enu = random_vehicle_state(Convention.ENU, seed=42)
     state_ned = state_enu.convert()
-    assert abs(state_enu.z - (-state_ned.z)) < 1e-10 
-    assert abs(state_enu.x - (+state_ned.y)) < 1e-10 
-    assert abs(state_enu.y - (+state_ned.x)) < 1e-10 
-    assert abs(state_enu.z_dot - (-state_ned.z_dot)) < 1e-10 
-    assert abs(state_enu.x_dot - (+state_ned.y_dot)) < 1e-10 
-    assert abs(state_enu.y_dot - (+state_ned.x_dot)) < 1e-10 
+    assert abs(state_enu.z - (-state_ned.z)) < 1e-10
+    assert abs(state_enu.x - (+state_ned.y)) < 1e-10
+    assert abs(state_enu.y - (+state_ned.x)) < 1e-10
+    assert abs(state_enu.z_dot - (-state_ned.z_dot)) < 1e-10
+    assert abs(state_enu.x_dot - (+state_ned.y_dot)) < 1e-10
+    assert abs(state_enu.y_dot - (+state_ned.x_dot)) < 1e-10
+
 
 if __name__ == "__main__":
     demo00()
     demo01()
     demo03()
-    quat_ned2enu = quat_mult(quat_from_rot_z(math.pi/2), quat_from_rot_x(math.pi))
+    quat_ned2enu = quat_mult(quat_from_rot_z(math.pi / 2), quat_from_rot_x(math.pi))
     print(quat_ned2enu)

--- a/examples/cpp_examples/README.md
+++ b/examples/cpp_examples/README.md
@@ -4,21 +4,21 @@
 
 ### For spawn_ships example
 
-1. Run LOTUSim
+**1. Run LOTUSim**
 
 In a first terminal, run:
    ```shell
    lotusim run
    ```
 
-2. Source environment
+**2. Source environment**
 
 In a second terminal, type the following:
    ```shell
    source ${LOTUSIM_WS}/install/setup.bash
    ```
 
-3. Run the example script
+**3. Run the example script**
 
 In the second terminal, type the following command:
    ```shell
@@ -29,28 +29,28 @@ In the second terminal, type the following command:
 
 ### For controlling_ships example
 
-1. Run XDYN
+**1. Run XDYN**
 
 In a first terminal, run:
    ```shell
    xdyn-for-cs $HOME/lotusim_ws/src/LOTUSim/assets/models/lrauv/lrauv.yml --verbose --address 127.0.0.1 --dt 0.2 --port 12346
    ```
 
-2. Run LOTUSim
+**2. Run LOTUSim**
 
 In a second terminal, run:
    ```shell
    lotusim run
    ```
 
-3. Run LOTUSim UI (optional)
+**3. Run LOTUSim UI (optional)**
 
 In a third terminal, run:
    ```shell
    lotusim ui
    ```
 
-4. Spawn the ship & send commands
+**4. Spawn the ship & send commands**
 
 In a fourth terminal, run:
    ```shell
@@ -64,11 +64,13 @@ In a fourth terminal, run:
 When building your own examples, keep the following in mind:
 
 **Vessel naming convention**
+
 When entities are spawned, their names are automatically assigned in the format `model_name_0`, `model_name_1`, ...
 The index increments for each new instance.
 👉 Make sure you use the correct vessel name when sending commands, otherwise they will not be applied.
 
 **Underwater vs surface behavior (important for XDyn connections)**
+
 XDyn determines whether a vessel is underwater or surface based on its z position:
     z <= -10 → underwater
     z >= 10 → aerial

--- a/examples/python-scripts/README.md
+++ b/examples/python-scripts/README.md
@@ -2,7 +2,7 @@
 
 ## Using LOTUSim with python
 
-0. Make the example script executable
+**0. Make the example script executable**
 
 In a first terminal, run:
    ```shell
@@ -16,28 +16,28 @@ This only needs to be done **once**, not every time you want to run the script.
 
 ### For spawning_ships example
 
-1. Run LOTUSim
+**1. Run LOTUSim**
 
 In a first terminal, run:
    ```shell
    lotusim run
    ```
 
-2. Source environment
+**2. Source environment**
 
 In a second terminal, type the following:
    ```shell
    source ${LOTUSIM_WS}/install/setup.bash
    ```
 
-3. Run the example script
+**3. Run the example script**
 
 In the second terminal, type the following command:
    ```shell
    python3 spawn_ships.py
    ```
 
-4. Optional: try other examples
+**4. Optional: try other examples**
 
 Inside 'spawn_ships.py', you can uncomment other spawn commands:
    ```shell
@@ -52,28 +52,28 @@ Then re-run the script to experiment with different models.
 
 ### For controlling_ships example
 
-1. Run XDYN
+**1. Run XDYN**
 
 In a first terminal, run:
    ```shell
    xdyn-for-cs $HOME/lotusim_ws/src/LOTUSim/assets/models/lrauv/lrauv.yml --verbose --address 127.0.0.1 --dt 0.2 --port 12346
    ```
 
-2. Run LOTUSim
+**2. Run LOTUSim**
 
 In a second terminal, run:
    ```shell
    lotusim run
    ```
 
-3. Run LOTUSim UI
+**3. Run LOTUSim UI**
 
 In a third terminal, run:
    ```shell
    lotusim ui
    ```
 
-4. Spawn the ship & send commands
+**4. Spawn the ship & send commands**
 
 In a fourth terminal, run:
    ```shell
@@ -87,11 +87,13 @@ In a fourth terminal, run:
 When building your own examples, keep the following in mind:
 
 **Vessel naming convention**
+
 When entities are spawned, their names are automatically assigned in the format `model_name_0`, `model_name_1`, ...
 The index increments for each new instance.
 👉 Make sure you use the correct vessel name when sending commands, otherwise they will not be applied.
 
 **Underwater vs surface behavior (important for XDyn connections)**
+
 XDyn determines whether a vessel is underwater or surface based on its z position:
     z <= -10 → underwater
     z >= 10 → aerial

--- a/systems/AGENTS.md
+++ b/systems/AGENTS.md
@@ -1,0 +1,220 @@
+# AGENTS.md - LOTUSim
+
+Documentation for coding agents and new contributors working in this repository. LOTUSim is an open-source (EPL-2.0) multi-agent naval simulator: ROS2 + Gazebo for orchestration and rendering, xdyn for rigid-body dynamics, coupled in co-simulation.
+
+## Architecture overview
+
+LOTUSim's Core Layer is built on Gazebo and organizes functionality into 6 **subsystems**: Physics, Sensor, Power, Rendering, Multi-agent, and Environment. Each are implemented as an independent Gazebo plugin that can be enabled, disabled, or replaced without affecting the others.
+
+Three more layers sit around that core:
+
+- **Internal Interface Layer** : the communication bridge (abstract base classes) between a subsystem and an external server.
+- **Internal Computation Layer** : user-operated **Engines** (Physics, Sensor, Power). Each Engine is a standalone server that receives state from its Interface, runs the relevant models, and returns results. This layer is external to the core of LOTUSim and can scale on multiple agents.
+- **External Interface Layer** : how user external applications (e.g.: navigation stacks, fleet managers, ...) talk to the simulation, primarily via a ROS 2 / FastDDS interface, plus a lightweight WebSocket interface.
+
+This client-server split is the reason LOTUSim can distribute computational load across machines instead of bottlenecking on one.
+
+A few terms worth noting:
+
+- **Entity** : anything in the simulation world (vessel, sensor, mesh).
+- **Agent** : an entity controlled by an external system via the ROS 2 interface (e.g. a vessel driven by xdyn or a Nav2 stack). Not every entity is an agent (a static obstacle is an entity but not an agent).
+- **`lotus_param`** : the custom XML block inside a model's SDF that each Subsystem plugin reads on spawn to configure itself. A model without this block is invisible to LOTUSim's plugins.
+
+Full details, diagrams, and the plugin lifecycle (PreUpdate → Update → PostUpdate) are on the wiki's [Architecture](https://github.com/naval-group/LOTUSim/wiki/Architecture) page.
+
+## How the components fit together
+
+LOTUSim runs as a co-simulation between three components:
+
+- **Gazebo (`gz`)** : world owner and, optionally, rendering.
+- **xdyn (optional)** : rigid-body dynamics, run as its own external process, not a Gazebo plugin. Gazebo's `physics_engine_interface` is a websocket *client* that connects to an `xdyn-for-cs` server (one per vessel, each on its own TCP port).
+- **Unity (optional)** : an alternative renderer to the Gazebo GUI, used by models that ship without a `<visual>` (see below).
+
+`lotusim run` starts `gz` only. To simulate a vessel with dynamics, start its `xdyn-for-cs` server first, e.g.:
+
+```bash
+lotusim run
+xdyn-for-cs $HOME/lotusim_ws/src/LOTUSim/assets/models/lrauv/lrauv.yml --verbose --address 127.0.0.1 --dt 0.2 --port 12346
+```
+
+Without an `xdyn-for-cs` listening on the matching port, the vessel spawns and renders but has no dynamics (`XdynWebsocket::onFail`).
+
+## Rendering: Gazebo GUI vs. Unity
+
+Some models (e.g. `wamv`, `dtmb_hull`, `lrauv`) ship collision geometry only and render through Unity via `render_plugin` → ROS2 → Unity client; so they won't appear in the Gazebo GUI by default. To see a vessel directly in `gz` without Unity, toggle *Entity Tree → right-click → View → Collisions*, or add a `<visual>` to the model.
+
+## Environment
+
+- Ubuntu 24.04 → ROS2 Jazzy + Gazebo Harmonic
+- ROS setup scripts are bash-only. Under zsh, source the `.zsh` variant (`setup.zsh`) instead, or use the `lotusim` wrapper (shebang `#!/bin/bash`).
+
+Two ways to install:
+
+### Container (recommended)
+
+A prebuilt image ships the full ROS2 + Gazebo + built LOTUSim workspace:
+
+```bash
+docker pull ghcr.io/naval-group/lotusim:latest
+docker run --rm -it ghcr.io/naval-group/lotusim:latest
+```
+
+To build/test a local change against the image's prebuilt workspace, mount your source, rebuild only the affected package:
+
+```bash
+docker run --rm -v "$PWD":/lotusim_ws/src/LOTUSim ghcr.io/naval-group/lotusim:latest \
+  bash -c 'source /opt/ros/$ROS_DISTRO/setup.bash && source /lotusim_ws/install/setup.bash \
+           && cd /lotusim_ws && colcon build --merge-install --packages-select <pkg>'
+```
+
+Headless (no GUI): good for builds, tests, and headless runs.
+
+### Building from source
+
+```bash
+lotusim install        # one-time: deps + build
+lotusim build          # rebuild workspace (colcon, --merge-install); clean_build to start over
+colcon build --merge-install --packages-select <pkg>   # single package
+```
+
+## Running a world
+
+- **With physics:** start one `xdyn-for-cs` per vessel (each on its own port), then `lotusim run <world>.world`.
+- **Without physics** (render / plugin debug): `lotusim run --gui <world>.world`.
+
+## Launching an example scenario
+
+There are 3 ways to launch a scenario:
+
+1. **Web UI** (best for quick, one-off scenarios with up to ~5 models):
+   `lotusim run` + `lotusim ui`, then use the **Scenarios** tab to add vessels, choose a model, and enable the plugins you want (Rendering, Physics via xdyn, and/or Waypoint Follower). Start one `xdyn-for-cs` per vessel using the physics engine, matching the port you set in the UI, then launch the scenario from the **Home** page.
+
+2. **Script-based** (C++, Python, or Jupyter: see the [`examples`](https://github.com/naval-group/LOTUSim/tree/main/examples) folder):
+   a script spawns vessels via the `mas_cmd` action, sends an SDF `lotus_param` snippet to configure their interfaces, and sends thruster
+   commands over `vessel_cmd_array`. You can check out the `LOTUSim/examples` folder.
+
+3. **`LOTUSim-generic-scenario`** package (best for spawning many agents at once from a reusable JSON config):
+   runs through its own standalone Unity executable rather than `lotusim ui` / `lotusim run`. Agents are defined in a JSON file specifying model, count, and initial poses (either `[lat, lon(, alt)]` or a full 6-element `[x, y, z, roll, pitch, yaw]`). See the package's own README for the full build/launch sequence.
+
+## Controlling a vessel
+
+There are two ways depending on what you need:
+
+Vessels are spawned via the Multi-Agent System's ROS 2 action interfaces (`mas_cmd` for one vessel, `mas_cmd_array` for several). `CREATE_CMD` sends a full `lotus_param` block as a string (`sdf_string`). What you put in that block decides which of the two control paths below you get.
+
+### Waypoint follower (kinematic, no physics engine needed)
+
+Good for scripted, predictable movement without an `xdyn-for-cs` server running. Two ways to drive it:
+
+- **Preset pattern at spawn** : declare a `<waypoint_follower>` in the `lotus_param` sent with `CREATE_CMD`, e.g. a looping circle:
+```xml
+  <lotus_param>
+      <waypoint_follower>
+          <follower>
+              <loop>true</loop>
+              <linear_accel_limit>0.5</linear_accel_limit>
+              <angular_accel_limit>0.005</angular_accel_limit>
+              <angular_velocities_limits>0.01</angular_velocities_limits>
+              <range_tolerance>2</range_tolerance>
+              <circle>
+                  <radius>10</radius>
+              </circle>
+          </follower>
+      </waypoint_follower>
+  </lotus_param>
+```
+- **Custom path at runtime** : call the vessel's `<vessel_name>/waypoints` service (`lotusim_msgs/srv/SetWaypoints`) with a list of `GeoPoint`s:
+```python
+  request = SetWaypoints.Request()
+  request.path = [GeoPoint(latitude=lat, longitude=lon, altitude=alt)]
+  request.loop = False
+  future = self.waypoint_client[model_name].call_async(request)
+```
+
+### Full dynamics (via xdyn)
+
+Needed for physically accurate motion driven by thruster commands. Requires `xdyn-for-cs` running for that vessel (see [Running a world](#running-a-world)).
+
+1. **Declare the physics interface at spawn**, matching the domain the vessel starts in (`underwater`, `surface`, or `aerial`), the xdyn
+   server's URI, and a name for each thruster:
+```xml
+   <lotus_param>
+       <physics_engine_interface>
+           <underwater>
+               <interface_type>XDynWebSocket</interface_type>
+               <uri>ws://127.0.0.1:12346</uri>
+               <thrusters>
+                   <thrusters1>propeller</thrusters1>
+               </thrusters>
+           </underwater>
+           <init_state>Underwater</init_state>
+       </physics_engine_interface>
+   </lotus_param>
+```
+2. **Publish thruster commands** on `/lotusim/vessel_cmd_array` (`lotusim_msgs/msg/VesselCmdArray`). Each command's `cmd_string` is JSON
+   keyed by the thruster name declared above:
+```python
+   cmd = VesselCmd()
+   cmd.vessel_name = vessel_name
+   cmd.cmd_string = json.dumps({"propeller(rpm)": 200.0, "propeller(P/D)": 0.88})
+   cmd_array.cmds.append(cmd)
+   self.cmd_publisher.publish(cmd_array)
+```
+
+> ⚠️ The thruster name declared in the SDF (`<thrusters1>propeller</thrusters1>`) and the key in the command JSON (`"propeller(rpm)"`) 
+> must match exactly. A mismatch will fail and the vessel just won't move.
+
+### Tracking and cleanup
+
+- Vessel positions stream on `/lotusim/poses` (`lotusim_msgs/msg/VesselPositionArray`) subscribe to track spawned vessels.
+- On shutdown, delete everything you spawned via `DELETE_CMD` on `mas_cmd_array`, referencing each vessel by the name given at spawn. 
+  Handle this in a signal handler block so Ctrl+C doesn't leave vessels behind.
+
+Full runnable examples: [`python-scripts/`](https://github.com/naval-group/LOTUSim/tree/main/examples) in the `examples` folder.
+
+
+### Adding a vehicle
+
+A model lives in `assets/models/<name>/`:
+
+- `model.config`
+- `model.sdf` : SDF format; version varies by model today (1.6–1.10). This is also where you declare a model's sensors and battery/ generator, and where the `lotus_param` block goes. A model without `lotus_param` won't be picked up by LOTUSim's plugins.
+- `.stl` mesh for the model
+- an xdyn `.yml` dynamics file : naming varies by model (`wamv.yaml`, `dtmb-xdyn.yml`, `fremmConfig.yaml`, …), declaring:
+  - `external forces` : passive forces the model always experiences, e.g. gravity, quadratic damping.
+  - `controlled forces` : propulsion you command at runtime, e.g. a `wageningen B-series` thruster, or `propeller+rudder` for rudder-steered
+    vessels. Give each a unique `name`. That name is what you address it by when sending thruster commands.
+  - See [Forces & Propulsion Types](https://github.com/naval-group/LOTUSim/wiki/forces-&-propulsion-(xdyn)) for the full list. Re-launch your scenario after editing the `.yml` for changes to take effect.
+
+Wire the model into a world via `<include>` + `<lotus_param>`. See [Extend with your components](https://github.com/naval-group/LOTUSim/wiki/extend-with-your-components) for adding new sensor/power-provider types rather than just using existing ones.
+
+
+## Coordinate conventions
+
+xdyn is NED, right-handed; Gazebo is ENU. Quaternion wire order is `qr, qi, qj, qk` (= w, x, y, z), by name. Gazebo↔Unity applies a `Z → -Y` transform on the Unity side.
+
+## Couple of things to note
+
+- **Process cleanup:** `pkill -f "gz sim"` or `pkill -f xdyn-for-cs` will match your own shell's command line too, so it can kill itself along with the target process. Capture the PID (`pid=$!`) and `kill "$pid"`, or use a `trap cleanup EXIT`.
+- **Restarting a run:** if a previous `gz`/`xdyn-for-cs` session didn't shut down cleanly, check for lingering processes on the ports you plan to use before starting a new one.
+
+## Contributing
+
+Issue (with the appropriate label) → announce yourself → fork → implement → test → PR referencing the issue (see `CONTRIBUTING.md`). EPL-2.0: never vendor GPL or non-redistributable assets. Whoever opens the PR answers for every line, AI-assisted or not.
+
+## Related repositories (naval-group)
+
+LOTUSim spans several repos, this core is only the simulation backend.
+
+- **LOTUSim** this repo: the simulator core (ROS2 + Gazebo + xdyn co-sim)
+- **LOTUSim-Xdyn** : the xdyn physics engine, a fork/mirror of the upstream at `gitlab.com/sirehna_naval_group/sirehna/xdyn`. 
+- **LOTUSim-generic-scenario** : reference controllers/scenarios (`src/agents/`), the auto-installer, and a prebuilt Unity player.
+- **LOTUSim-Unity-modules** : frontend (an alternative to the Gazebo GUI).
+- **LOTUSim-UI-frontend** (React), **LOTUSim-UI-backend** the web UI.
+
+## Further reading
+
+- **Project wiki** : full documentation (installation, models, architecture, tutorials, FAQ): https://github.com/naval-group/LOTUSim/wiki
+- **Getting Started** : fastest path from zero to a running simulation https://github.com/naval-group/LOTUSim/wiki/Getting-Started
+- **Architecture** : subsystems, interfaces, engines, and the `lotus_param` block in full detail: https://github.com/naval-group/LOTUSim/wiki/Architecture
+- **Tutorial** : creating scenarios, commanding vessels, extending with your components, and customising models step by step: https://github.com/naval-group/LOTUSim/wiki/Tutorial

--- a/systems/physics_engine_interface/CMakeLists.txt
+++ b/systems/physics_engine_interface/CMakeLists.txt
@@ -97,6 +97,24 @@ install(
 )
 
 #============================================================================
+# Testing
+#============================================================================
+if(BUILD_TESTING)
+  find_package(ament_cmake_gtest REQUIRED)
+
+  # Unit tests on the NED<->ENU conversions (pure functions living in the
+  # plugin library). The test forward-declares them and links the library, so
+  # it does not need the plugin's websocketpp/json include chain.
+  ament_add_gtest(test_ned_enu_conversions test/test_ned_enu_conversions.cpp)
+  if(TARGET test_ned_enu_conversions)
+    target_link_libraries(test_ned_enu_conversions
+      physics_interface_plugin
+      gz-sim8::gz-sim8
+    )
+  endif()
+endif()
+
+#============================================================================
 # Export
 #============================================================================
 ament_export_targets(export_physics_interface_plugin HAS_LIBRARY_TARGET)

--- a/systems/physics_engine_interface/README.md
+++ b/systems/physics_engine_interface/README.md
@@ -81,7 +81,7 @@ Recognised `interface_type`/`connection_type` values: `XDYNWEBSOCKET` → `XdynW
 
 A **singleton** WebSocket client connecting to xdyn - one shared client instance handles every vessel's connections, keyed internally by Gazebo entity.
 
-**Coordinate conversion:** xdyn communicates in NED; Gazebo uses ENU. Every message is converted both ways (`vecNedToEnu`/`vecEnuToNed`, `quatNedToEnu`/`quatEnuToNed`) using a fixed basis-change quaternion.
+**Coordinate conversion:** xdyn communicates in NED; Gazebo uses ENU. Every message is converted both ways (`vecNedToEnu*`/`vecEnuToNed*`, `quatNedToEnu`/`quatEnuToNed`) using a fixed basis-change quaternion.
 
 **Per-tick protocol** (`getNewState`): builds a co-simulation request - `Dt` (converted from milliseconds to seconds), one `states` entry (the vessel's current pose/velocity converted to NED), and `commands` (pulled from the shared command map, populated by `<thrusters>` config or later overridden via ROS commands). The reply's `z` value is used to infer which domain the vessel *should* be in next: `z ≥ 10` → Aerial, `z ≤ -10` → Underwater, otherwise Surface (`z` is NED, so positive is down - this is why deep values map to Underwater and negative/high values map to Aerial).
 

--- a/systems/physics_engine_interface/include/physics_engine_interface/xdyn_websocket.hpp
+++ b/systems/physics_engine_interface/include/physics_engine_interface/xdyn_websocket.hpp
@@ -32,6 +32,8 @@ using json = nlohmann::json;
 
 static const gz::math::Quaterniond
     q_ned_to_enu(0.0, 0.5 * sqrt(2.0), 0.5 * sqrt(2.0), 0.0);
+// Body-frame convention swap (gz FLU <-> xdyn FRD): 180 deg about body-x.
+static const gz::math::Quaterniond q_flu_to_frd(0.0, 1.0, 0.0, 0.0);
 
 gz::math::Quaterniond quatNedToEnu(const gz::math::Quaterniond& q_ned);
 gz::math::Quaterniond quatEnuToNed(const gz::math::Quaterniond& q_enu);

--- a/systems/physics_engine_interface/include/physics_engine_interface/xdyn_websocket.hpp
+++ b/systems/physics_engine_interface/include/physics_engine_interface/xdyn_websocket.hpp
@@ -37,8 +37,10 @@ static const gz::math::Quaterniond q_flu_to_frd(0.0, 1.0, 0.0, 0.0);
 
 gz::math::Quaterniond quatNedToEnu(const gz::math::Quaterniond& q_ned);
 gz::math::Quaterniond quatEnuToNed(const gz::math::Quaterniond& q_enu);
-gz::math::Vector3d vecNedToEnu(const gz::math::Vector3d& v_ned);
-gz::math::Vector3d vecEnuToNed(const gz::math::Vector3d& v_enu);
+gz::math::Vector3d vecNedToEnuFixedFrame(const gz::math::Vector3d& v_ned);
+gz::math::Vector3d vecNedToEnuBodyFrame(const gz::math::Vector3d& v_ned);
+gz::math::Vector3d vecEnuToNedFixedFrame(const gz::math::Vector3d& v_enu);
+gz::math::Vector3d vecEnuToNedBodyFrame(const gz::math::Vector3d& v_ned);
 
 constexpr unsigned short DEFAULT_WEBSOCKET_TIMEOUT = 5;
 

--- a/systems/physics_engine_interface/package.xml
+++ b/systems/physics_engine_interface/package.xml
@@ -16,6 +16,8 @@
   <depend>lotusim_msgs</depend>
   <depend>lotusim_common</depend>
 
+  <test_depend>ament_cmake_gtest</test_depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/systems/physics_engine_interface/src/physics_interface_plugin.cpp
+++ b/systems/physics_engine_interface/src/physics_interface_plugin.cpp
@@ -294,13 +294,14 @@ void PhysicsInterfacePlugin::createDomainInterface(
     std::unordered_map<gz::sim::Entity, std::shared_ptr<PhysicsInterfaceBase>>&
         _interface_map)
 {
-    InterfaceType interface_type;
-    if (!_physics_sdf->HasElement("connection_type") ||
+    InterfaceType interface_type = InterfaceType::Unknown;
+    if (!_physics_sdf->HasElement("connection_type") &&
         !_physics_sdf->HasElement("interface_type")) {
-        m_logger->warn(
-            "PhysicsInterfacePlugin::createDomainInterface: {} missing {} interface_type or uri.",
+        m_logger->error(
+            "PhysicsInterfacePlugin::createDomainInterface: {} missing {} interface_type. Removing physics calculation.",
             _vessel_name,
             DomainTypeToStringMap[_domain]);
+        return;
     }
     try {
         // Temp support of legacy type connection_type, changing to

--- a/systems/physics_engine_interface/src/xdyn_websocket.cpp
+++ b/systems/physics_engine_interface/src/xdyn_websocket.cpp
@@ -318,8 +318,8 @@ void XdynWebsocket::onMessage(
     auto ned_quad = gz::math::Quaterniond(
         reply["qr"].back().get<double>(),
         reply["qi"].back().get<double>(),
-        reply["qk"].back().get<double>(),
-        reply["qj"].back().get<double>());
+        reply["qj"].back().get<double>(),
+        reply["qk"].back().get<double>());
 
     auto gz_position = vecNedToEnu(ned_position);
     auto gz_quad = quatNedToEnu(ned_quad);

--- a/systems/physics_engine_interface/src/xdyn_websocket.cpp
+++ b/systems/physics_engine_interface/src/xdyn_websocket.cpp
@@ -11,18 +11,24 @@
 
 namespace lotusim::gazebo {
 
-// Convert a quaternion from the NED frame to the ENU frame by conjugating it
-// with the basis-change quaternion that maps [N, E, D] coordinates to [E, N,
-// -D].
+// Convert a quaternion from the NED frame to the ENU frame
+
+// An attitude quaternion maps body axes to world axes, so converting it
+// between conventions changes BOTH frames: world swap (ENU<->NED) on the
+// left, body swap (FLU<->FRD) on the right. A similarity transform
+// (q_swap * q * q_swap^-1) only relabels the world frame and yields
+// yaw_ned = -yaw_enu instead of the correct yaw_ned = pi/2 - yaw_enu.
+// Both swap factors are 180-deg rotations (involutive up to sign), so the
+// same product converts in either direction.
 gz::math::Quaterniond quatNedToEnu(const gz::math::Quaterniond& q_ned)
 {
-    return q_ned_to_enu * q_ned * q_ned_to_enu.Inverse();
+    return q_ned_to_enu * q_ned * q_flu_to_frd;
 }
 
 // Convert a quaternion from the ENU frame back to the NED frame.
 gz::math::Quaterniond quatEnuToNed(const gz::math::Quaterniond& q_enu)
 {
-    return q_ned_to_enu.Inverse() * q_enu * q_ned_to_enu;
+    return q_ned_to_enu * q_enu * q_flu_to_frd;
 }
 
 gz::math::Vector3d vecNedToEnu(const gz::math::Vector3d& v_ned)

--- a/systems/physics_engine_interface/src/xdyn_websocket.cpp
+++ b/systems/physics_engine_interface/src/xdyn_websocket.cpp
@@ -363,7 +363,11 @@ XdynWebsocket::getNewState(
     data["Dt"] = time_diff / 1000.0;
     data["states"] = json::array();
     json previous_state_json = {
-        {"t", time_diff},
+        // Absolute sim time in seconds: xdyn uses states.back().t as the
+        // integration start time, and time-dependent forcings (waves) need the
+        // true clock. The raw step duration in ms sent here previously froze
+        // xdyn's clock at ~Dt, which is only harmless on calm water.
+        {"t", previous_state.time},
         {"x", ned_position.X()},
         {"y", ned_position.Y()},
         {"z", ned_position.Z()},

--- a/systems/physics_engine_interface/src/xdyn_websocket.cpp
+++ b/systems/physics_engine_interface/src/xdyn_websocket.cpp
@@ -123,18 +123,43 @@ bool XdynWebsocket::configureInterface(
     }
     m_uri[_entity][domain_type] = uri;
 
-    if (_sdf->HasElement("thrusters") && m_models_cmd_map_ptr) {
-        auto sdfPtr_thruster = _sdf->GetElement("thrusters")->GetFirstElement();
-        auto thrusters_cmd = json::object();
-        do {
-            std::string thruster_name = sdfPtr_thruster->Get<std::string>();
-            thrusters_cmd[thruster_name + "(rpm)"] =
-                50.0;  // was 2.0 but crashes the Wageningen propeller
-            thrusters_cmd[thruster_name + "(P/D)"] = 0.79;
-            thrusters_cmd[thruster_name + "(beta)"] = 0.0;
-            sdfPtr_thruster = sdfPtr_thruster->GetNextElement();
-        } while (sdfPtr_thruster != sdf::ElementPtr(nullptr));
-        (*m_models_cmd_map_ptr)[_entity] = thrusters_cmd.dump();
+    if (m_models_cmd_map_ptr) {
+        auto initial_cmd = json::object();
+
+        // Propellers: each <thrusters> entry seeds its rpm/pitch/beta signals.
+        if (_sdf->HasElement("thrusters")) {
+            auto sdfPtr_thruster =
+                _sdf->GetElement("thrusters")->GetFirstElement();
+            do {
+                std::string thruster_name = sdfPtr_thruster->Get<std::string>();
+                initial_cmd[thruster_name + "(rpm)"] =
+                    50.0;  // was 2.0 but crashes the Wageningen propeller
+                initial_cmd[thruster_name + "(P/D)"] = 0.79;
+                initial_cmd[thruster_name + "(beta)"] = 0.0;
+                sdfPtr_thruster = sdfPtr_thruster->GetNextElement();
+            } while (sdfPtr_thruster != sdf::ElementPtr(nullptr));
+        }
+
+        // Angle-commanded actuators (rudders, sails, fins): each
+        // <control_surfaces> entry is the full xdyn command signal,
+        // e.g. "rudder(angle)" or "mainsail(sheet)", seeded to 0.0 so that
+        // commands.at(<signal>) does not throw before the first ROS setpoint.
+        // The default seeding from <thrusters> only does not cover these, so a
+        // vessel driven solely by control surfaces would otherwise crash the
+        // co-simulation on its first step.
+        if (_sdf->HasElement("control_surfaces")) {
+            auto sdfPtr_surface =
+                _sdf->GetElement("control_surfaces")->GetFirstElement();
+            do {
+                std::string signal = sdfPtr_surface->Get<std::string>();
+                initial_cmd[signal] = 0.0;
+                sdfPtr_surface = sdfPtr_surface->GetNextElement();
+            } while (sdfPtr_surface != sdf::ElementPtr(nullptr));
+        }
+
+        if (!initial_cmd.empty()) {
+            (*m_models_cmd_map_ptr)[_entity] = initial_cmd.dump();
+        }
     }
     return true;
 }

--- a/systems/physics_engine_interface/src/xdyn_websocket.cpp
+++ b/systems/physics_engine_interface/src/xdyn_websocket.cpp
@@ -31,14 +31,24 @@ gz::math::Quaterniond quatEnuToNed(const gz::math::Quaterniond& q_enu)
     return q_ned_to_enu * q_enu * q_flu_to_frd;
 }
 
-gz::math::Vector3d vecNedToEnu(const gz::math::Vector3d& v_ned)
+gz::math::Vector3d vecNedToEnuFixedFrame(const gz::math::Vector3d& v_ned)
 {
     return {v_ned.Y(), v_ned.X(), -v_ned.Z()};
 }
 
-gz::math::Vector3d vecEnuToNed(const gz::math::Vector3d& v_enu)
+gz::math::Vector3d vecNedToEnuBodyFrame(const gz::math::Vector3d& v_ned)
+{
+    return {v_ned.X(), -v_ned.Y(), -v_ned.Z()};
+}
+
+gz::math::Vector3d vecEnuToNedFixedFrame(const gz::math::Vector3d& v_enu)
 {
     return {v_enu.Y(), v_enu.X(), -v_enu.Z()};
+}
+
+gz::math::Vector3d vecEnuToNedBodyFrame(const gz::math::Vector3d& v_enu)
+{
+    return {v_enu.X(), -v_enu.Y(), -v_enu.Z()};
 }
 
 std::shared_ptr<XdynWebsocket> XdynWebsocket::m_instance = nullptr;
@@ -352,7 +362,7 @@ void XdynWebsocket::onMessage(
         reply["qj"].back().get<double>(),
         reply["qk"].back().get<double>());
 
-    auto gz_position = vecNedToEnu(ned_position);
+    auto gz_position = vecNedToEnuFixedFrame(ned_position);
     auto gz_quad = quatNedToEnu(ned_quad);
 
     auto ned_lin_vel = gz::math::Vector3d{
@@ -365,8 +375,8 @@ void XdynWebsocket::onMessage(
         reply["q"].back().get<double>(),
         reply["r"].back().get<double>());
 
-    auto gz_lin_vel = vecNedToEnu(ned_lin_vel);
-    auto gz_angular_vel = vecNedToEnu(ned_angular_vel);
+    auto gz_lin_vel = vecNedToEnuBodyFrame(ned_lin_vel);
+    auto gz_angular_vel = vecNedToEnuBodyFrame(ned_angular_vel);
 
     VesselInformation new_state;
     new_state.time = reply["t"].back().get<double>();
@@ -385,10 +395,14 @@ XdynWebsocket::getNewState(
     const VesselInformation& previous_state,
     float time_diff)
 {
-    gz::math::Vector3d ned_position = vecEnuToNed(previous_state.pose.Pos());
-    gz::math::Quaterniond ned_quad = quatEnuToNed(previous_state.pose.Rot());
-    gz::math::Vector3d ned_lin_vel = vecEnuToNed(previous_state.lin_vel);
-    gz::math::Vector3d ned_angular_vel = vecEnuToNed(previous_state.ang_vel);
+    const gz::math::Vector3d ned_position =
+        vecEnuToNedFixedFrame(previous_state.pose.Pos());
+    const gz::math::Quaterniond ned_quad =
+        quatEnuToNed(previous_state.pose.Rot());
+    const gz::math::Vector3d ned_lin_vel =
+        vecEnuToNedBodyFrame(previous_state.lin_vel);
+    const gz::math::Vector3d ned_angular_vel =
+        vecEnuToNedBodyFrame(previous_state.ang_vel);
 
     json data = json::object();
     data["Dt"] = time_diff / 1000.0;

--- a/systems/physics_engine_interface/test/test_ned_enu_conversions.cpp
+++ b/systems/physics_engine_interface/test/test_ned_enu_conversions.cpp
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2025 Naval Group
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+#include <gtest/gtest.h>
+
+#include <gz/math/Quaternion.hh>
+#include <gz/math/Vector3.hh>
+
+#include <cmath>
+
+// These free functions are defined in physics_interface_plugin
+// (src/xdyn_websocket.cpp) and declared in xdyn_websocket.hpp. They are
+// forward-declared here so the test does not pull in the plugin's heavy
+// websocketpp / nlohmann-json includes; the test links the library to resolve
+// them at link time.
+namespace lotusim::gazebo {
+gz::math::Quaterniond quatNedToEnu(const gz::math::Quaterniond& q_ned);
+gz::math::Quaterniond quatEnuToNed(const gz::math::Quaterniond& q_enu);
+gz::math::Vector3d vecNedToEnu(const gz::math::Vector3d& v_ned);
+gz::math::Vector3d vecEnuToNed(const gz::math::Vector3d& v_enu);
+}  // namespace lotusim::gazebo
+
+using gz::math::Quaterniond;
+using gz::math::Vector3d;
+using lotusim::gazebo::quatEnuToNed;
+using lotusim::gazebo::quatNedToEnu;
+using lotusim::gazebo::vecEnuToNed;
+using lotusim::gazebo::vecNedToEnu;
+
+namespace {
+constexpr double kTol = 1e-9;
+
+const Quaterniond kIdentity(1.0, 0.0, 0.0, 0.0);
+
+void expectQuatNear(const Quaterniond& a, const Quaterniond& b, double tol = kTol)
+{
+    EXPECT_NEAR(a.W(), b.W(), tol);
+    EXPECT_NEAR(a.X(), b.X(), tol);
+    EXPECT_NEAR(a.Y(), b.Y(), tol);
+    EXPECT_NEAR(a.Z(), b.Z(), tol);
+}
+}  // namespace
+
+// NED (X=North, Y=East, Z=Down) -> ENU (X=East, Y=North, Z=Up):
+// swap X/Y, flip Z.
+TEST(NedEnuConversions, VecNedToEnuKnownValue)
+{
+    const Vector3d enu = vecNedToEnu({1.0, 2.0, 3.0});
+    EXPECT_NEAR(enu.X(), 2.0, kTol);
+    EXPECT_NEAR(enu.Y(), 1.0, kTol);
+    EXPECT_NEAR(enu.Z(), -3.0, kTol);
+}
+
+// The axis permutation is its own inverse: NED->ENU->NED is the identity.
+// vecNedToEnu and vecEnuToNed share the same body on purpose (the swap is an
+// involution) — this guards that from being "fixed" into a real bug.
+TEST(NedEnuConversions, VecRoundTripIsIdentity)
+{
+    const Vector3d v{1.0, 2.0, 3.0};
+    const Vector3d back = vecEnuToNed(vecNedToEnu(v));
+    EXPECT_NEAR(back.X(), v.X(), kTol);
+    EXPECT_NEAR(back.Y(), v.Y(), kTol);
+    EXPECT_NEAR(back.Z(), v.Z(), kTol);
+}
+
+// An orientation converted NED->ENU->NED must come back unchanged.
+TEST(NedEnuConversions, QuatRoundTripIsIdentity)
+{
+    const double d2r = M_PI / 180.0;
+    const Quaterniond q(12.0 * d2r, -8.0 * d2r, 30.0 * d2r);  // roll, pitch, yaw
+    expectQuatNear(q, quatEnuToNed(quatNedToEnu(q)));
+}
+
+// A level orientation stays level.
+TEST(NedEnuConversions, IdentityMapsToIdentity)
+{
+    expectQuatNear(kIdentity, quatNedToEnu(kIdentity));
+}
+
+// Heading sign flips between frames: a +90 deg NED heading (clockwise from
+// North, about Down) is a -90 deg ENU yaw (counter-clockwise from East, about
+// Up). This is exactly the class of axis/handedness error a broken quaternion
+// mapping produces (cf. the xdyn qj/qk fix).
+TEST(NedEnuConversions, NedHeadingBecomesOppositeEnuYaw)
+{
+    const double yaw_ned = 90.0 * M_PI / 180.0;
+    const Quaterniond q_ned(0.0, 0.0, yaw_ned);
+    const Vector3d euler = quatNedToEnu(q_ned).Euler();  // roll, pitch, yaw
+    EXPECT_NEAR(euler.X(), 0.0, 1e-6);
+    EXPECT_NEAR(euler.Y(), 0.0, 1e-6);
+    EXPECT_NEAR(euler.Z(), -yaw_ned, 1e-6);
+}

--- a/systems/physics_engine_interface/test/test_ned_enu_conversions.cpp
+++ b/systems/physics_engine_interface/test/test_ned_enu_conversions.cpp
@@ -9,10 +9,9 @@
  */
 #include <gtest/gtest.h>
 
+#include <cmath>
 #include <gz/math/Quaternion.hh>
 #include <gz/math/Vector3.hh>
-
-#include <cmath>
 
 // These free functions are defined in physics_interface_plugin
 // (src/xdyn_websocket.cpp) and declared in xdyn_websocket.hpp. They are
@@ -22,23 +21,26 @@
 namespace lotusim::gazebo {
 gz::math::Quaterniond quatNedToEnu(const gz::math::Quaterniond& q_ned);
 gz::math::Quaterniond quatEnuToNed(const gz::math::Quaterniond& q_enu);
-gz::math::Vector3d vecNedToEnu(const gz::math::Vector3d& v_ned);
-gz::math::Vector3d vecEnuToNed(const gz::math::Vector3d& v_enu);
+gz::math::Vector3d vecNedToEnuFixedFrame(const gz::math::Vector3d& v_ned);
+gz::math::Vector3d vecEnuToNedFixedFrame(const gz::math::Vector3d& v_enu);
 }  // namespace lotusim::gazebo
 
 using gz::math::Quaterniond;
 using gz::math::Vector3d;
 using lotusim::gazebo::quatEnuToNed;
 using lotusim::gazebo::quatNedToEnu;
-using lotusim::gazebo::vecEnuToNed;
-using lotusim::gazebo::vecNedToEnu;
+using lotusim::gazebo::vecEnuToNedFixedFrame;
+using lotusim::gazebo::vecNedToEnuFixedFrame;
 
 namespace {
 constexpr double kTol = 1e-9;
 
 const Quaterniond kIdentity(1.0, 0.0, 0.0, 0.0);
 
-void expectQuatNear(const Quaterniond& a, const Quaterniond& b, double tol = kTol)
+void expectQuatNear(
+    const Quaterniond& a,
+    const Quaterniond& b,
+    double tol = kTol)
 {
     EXPECT_NEAR(a.W(), b.W(), tol);
     EXPECT_NEAR(a.X(), b.X(), tol);
@@ -51,19 +53,20 @@ void expectQuatNear(const Quaterniond& a, const Quaterniond& b, double tol = kTo
 // swap X/Y, flip Z.
 TEST(NedEnuConversions, VecNedToEnuKnownValue)
 {
-    const Vector3d enu = vecNedToEnu({1.0, 2.0, 3.0});
+    const Vector3d enu = vecNedToEnuFixedFrame({1.0, 2.0, 3.0});
     EXPECT_NEAR(enu.X(), 2.0, kTol);
     EXPECT_NEAR(enu.Y(), 1.0, kTol);
     EXPECT_NEAR(enu.Z(), -3.0, kTol);
 }
 
 // The axis permutation is its own inverse: NED->ENU->NED is the identity.
-// vecNedToEnu and vecEnuToNed share the same body on purpose (the swap is an
-// involution) — this guards that from being "fixed" into a real bug.
+// vecNedToEnuFixedFrame and vecEnuToNedFixedFrame share the same body on
+// purpose (the swap is an involution) — this guards that from being "fixed"
+// into a real bug.
 TEST(NedEnuConversions, VecRoundTripIsIdentity)
 {
     const Vector3d v{1.0, 2.0, 3.0};
-    const Vector3d back = vecEnuToNed(vecNedToEnu(v));
+    const Vector3d back = vecEnuToNedFixedFrame(vecNedToEnuFixedFrame(v));
     EXPECT_NEAR(back.X(), v.X(), kTol);
     EXPECT_NEAR(back.Y(), v.Y(), kTol);
     EXPECT_NEAR(back.Z(), v.Z(), kTol);
@@ -73,7 +76,10 @@ TEST(NedEnuConversions, VecRoundTripIsIdentity)
 TEST(NedEnuConversions, QuatRoundTripIsIdentity)
 {
     const double d2r = M_PI / 180.0;
-    const Quaterniond q(12.0 * d2r, -8.0 * d2r, 30.0 * d2r);  // roll, pitch, yaw
+    const Quaterniond q(
+        12.0 * d2r,
+        -8.0 * d2r,
+        30.0 * d2r);  // roll, pitch, yaw
     expectQuatNear(q, quatEnuToNed(quatNedToEnu(q)));
 }
 


### PR DESCRIPTION
This pull request mainly contains @cmoron 's work, that identified frame and quaternions issues between LOTUSim and xdyn. These commits were produced while designing a sail ship demo.

At least, three fixes are proposed:

- Fix(physics_engine_interface): correct xdyn quaternion j/k mapping on receive
- Fix(physics_engine_interface): send absolute sim time to xdyn, not step duration in ms
- Fix(physics_engine_interface): include body-frame swap in NED<->ENU attitude conversion

I suspect other fixes should be done for the 3d part with Unity, that is stored [here](https://github.com/naval-group/LOTUSim-Unity-modules/blob/main/Assets/Scripts/lotusim_interface/common.cs): GZ (ENU) <-> Unity (Left handed frame, with Y up)

If needed, this pull request can be split to clearly identify bug fixes, CI and AI agents files.
