### PR TITLE
docs: remove duplication between VISION.md and CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,30 +2,14 @@
 
 This document explains how to contribute to the LOTUSim project.
 
-## Contribution Philosophy
-LOTUSim aims to foster research, experimentation, and interoperability in the field of multi-agent simulation.
+## Scope
 
-A LOTUSim Governance Committee, established within Naval Group, oversees the overall coherence of the project’s developments.
-In the future, the committee may include external personas (key partners or major contributors).
+A few points of scope are worth stating here, as they shape what fits the project.
 
-The committee publishes a roadmap highlighting priority topics and features, based on:
-- Internal needs within Naval Group,
-- Partner priorities,
-- And community-driven contributions.
+- **Proprietary names.** Contributions must not expose the names of proprietary platforms or sensors without agreement. Respect each organisation's wishes about being named or not - some choose to be credited, others do not.
+- **AI-generated code.** Treat it with care. Understand, review and verify what you submit. Do not pour in thousands of lines doing forty things at once - one focused change at a time.
 
-This roadmap is updated every six months and available in the [`VISION.md`](VISION.md#current-focus) file, under "Current Focus" and "Next".
-
-New ideas that enrich LOTUSim are always welcome, even if they are not listed on the roadmap.
-
-- For roadmap-related questions, please contact the [Product Owner](mailto:lotusim_support@naval-group.com).
-
-The LOTUSim Governance Committee ensures:
-
-- Technical consistency of the project core,
-- Validation of contributions,
-- Release publication in alignment with the roadmap.
-
-Before proposing a contribution, please first open an issue (see the Technical Specification section).
+This is a guardrail for a project that means to stay open and modular, not an exhaustive rulebook. Strong rationale and strong community demand can move it.
 
 ## Types of Contributions
 You can contribute in several ways:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 This document explains how to contribute to the LOTUSim project.
 
-## Scope
+## Guardrails
 
 A few points of scope are worth stating here, as they shape what fits the project.
 
@@ -19,6 +19,8 @@ You can contribute in several ways:
 - Enhancements – improving existing functions or models.
 - Data contributions – use cases, simulation scenarios, or datasets.
 - Bug fixes – code corrections, refactoring, or readability/maintainability improvements.
+
+## Contribution Process
 
 Please follow this process to propose changes:
 
@@ -57,4 +59,4 @@ Please follow this process to propose changes:
 All pull requests are reviewed by maintainers and, if relevant, by the LOTUSim Governance Committee.
 Feedback may include requests for clarification, documentation, or code improvements.
 
-Once approved, your contribution will be merged into the main branch and included in the next release according to the project roadmap.
+Once approved, your contribution will be merged into the main branch and included in the next release according to the [project roadmap](VISION.md#current-focus).

--- a/VISION.md
+++ b/VISION.md
@@ -11,6 +11,29 @@ LOTUSim was born from the work of Naval Group PhD students, in France and around
 That is the mission: to make the work of algorithm designers, research engineers,
 human-factors specialists and roboticists simpler and more effective, by giving them a common playground for their work.
 
+## Contribution Philosophy
+
+LOTUSim aims to foster research, experimentation, and interoperability in the
+field of multi-agent simulation.
+
+A LOTUSim Governance Committee, established within Naval Group, oversees the
+overall coherence of the project's developments. In the future, the committee
+may include external personas (key partners or major contributors).
+
+The committee publishes a roadmap highlighting priority topics and features,
+based on:
+- Internal needs within Naval Group,
+- Partner priorities,
+- And community-driven contributions.
+
+New ideas that enrich LOTUSim are always welcome, even if they are not listed
+on the roadmap.
+
+The LOTUSim Governance Committee ensures:
+- Technical consistency of the project core,
+- Validation of contributions,
+- Release publication in alignment with the roadmap.
+
 ## Current Focus
 
 The priorities for the current period are:
@@ -42,26 +65,9 @@ These two axes are our internal focus. We strongly encourage the community to bu
 LOTUSim's technical choices serve three objectives: openness (open-source, built on open standards), modularity (add or swap model, sensors and algorithms) and flexibility (configure the simulation to fit your need). The core, governed by Naval Group, holds the architecture, the interfaces and the foundational bricks, and we remain firm there: the main directions are ours to set and to carry.
 Around that core, models, sensors and scenarios are open to community contribution.
 
-- **ROS2** - the de facto standard of robotics. It makes LOTUSim naturally compatible
-  with the real software bricks roboticists work with, so that algorithms built in
-  simulation transpose toward hardware.
-- **Gazebo** - a mature open-source robotics simulator providing physics and sensor
-  rendering, with native ROS2 integration.
-- **xdyn** - an open-source (EPL-2.0) hydrodynamics engine developed by Sirehna. It solves the equations of motion for surface and underwater vehicles under real sea conditions, bringing a level of physical fidelity a generic robotics simulator does not cover - a differentiating brick for the naval domain.
-- **C++** - the the core language, chosen for performance and real-time execution, long favoured by industry for demanding simulation. 
-- **Python** - the accessible layer on top : the language of algorithm designers and the R&D/AI community, with ready examples for users.
+Full details: [LOTUSim Architecture wiki](https://github.com/naval-group/LOTUSim/wiki/LOTUSim-Architecture).
 
-MCP support follows the same logic of openness: exposing LOTUSim so that AI agents can orchestrate it - for instance, going from a natural-language scenario description to a
-running simulation.
-
-## Contributing & Scope
-
-The full contribution process lives in [`CONTRIBUTING.md`](CONTRIBUTING.md). A few points of scope are worth stating here, as they shape what fits the project.
-
-- **Proprietary names.** Contributions must not expose the names of proprietary platforms or sensors without agreement. Respect each organisation's wishes about being named or not - some choose to be credited, others do not.
-- **AI-generated code.** Treat it with care. Understand, review and verify what you submit. Do not pour in thousands of lines doing forty things at once - one focused change at a time, as set out in [`CONTRIBUTING.md`](CONTRIBUTING.md).
-
-This is a guardrail for a project that means to stay open and modular, not an exhaustive rulebook. Strong rationale and strong community demand can move it.
+The full contribution process lives in [`CONTRIBUTING.md`](CONTRIBUTING.md).
 
 ## References
 

--- a/VISION.md
+++ b/VISION.md
@@ -4,17 +4,13 @@ LOTUSim is the first open-source simulation tool released by a major player in F
 naval simulation, across both military and civil domains.
 
 This document sets out where LOTUSim stands today and where it is heading. It complements, and does not replace, the contribution rules.
-How to contribute: [`CONTRIBUTING.md`](CONTRIBUTING.md)
 
 LOTUSim was born from the work of Naval Group PhD students, in France and around the world, at IRL CROSSING in Australia and at Naval Group Far East in Singapore. Together we decided to offer a shared environment so that PhD students could focus on their research rather than on coding a simulation bench. What started with PhD students quickly proved useful well beyond them : to research engineers,algorithm designers and R&D teams at large.
 
 That is the mission: to make the work of algorithm designers, research engineers,
 human-factors specialists and roboticists simpler and more effective, by giving them a common playground for their work.
 
-## Contribution Philosophy
-
-LOTUSim aims to foster research, experimentation, and interoperability in the
-field of multi-agent simulation.
+## Philosophy & Governance
 
 A LOTUSim Governance Committee, established within Naval Group, oversees the
 overall coherence of the project's developments. In the future, the committee
@@ -33,6 +29,8 @@ The LOTUSim Governance Committee ensures:
 - Technical consistency of the project core,
 - Validation of contributions,
 - Release publication in alignment with the roadmap.
+
+How to contribute: [`CONTRIBUTING.md`](CONTRIBUTING.md)
 
 ## Current Focus
 
@@ -66,12 +64,3 @@ LOTUSim's technical choices serve three objectives: openness (open-source, built
 Around that core, models, sensors and scenarios are open to community contribution.
 
 Full details: [LOTUSim Architecture wiki](https://github.com/naval-group/LOTUSim/wiki/LOTUSim-Architecture).
-
-The full contribution process lives in [`CONTRIBUTING.md`](CONTRIBUTING.md).
-
-## References
-
-- Contribution rules: [`CONTRIBUTING.md`](CONTRIBUTING.md)
-- License: EPL-2.0 - every contribution is made under this license.
-- Repository: [`naval-group/LOTUSim`](https://github.com/naval-group/LOTUSim/)
-- Roadmap and product questions: the Product Owner - lotusim_support@naval-group.com


### PR DESCRIPTION
Follow-up to PR #56.

## What changed
- Moved the governance/roadmap content (committee, roadmap cadence) from
  CONTRIBUTING.md into VISION.md, under a new "Philosophy & Governance"
  section.
- Moved the scope guardrails (proprietary names, AI-generated code) from
  VISION.md into CONTRIBUTING.md, under a new "Guardrails" section.
- Replaced the tech stack list in VISION.md (ROS2, Gazebo, xdyn...) with
  a link to the Architecture wiki page.

## About @estherRay's comment on #56
This PR removes the actual overlap between the two files, so the
content isn't duplicated even though the files stay separate. Happy to
discuss if you'd still have any suggestion