### PR TITLE
Integrate IRL CROSSING thruster-seeding fix + resolve related xdyn crash

### DIFF
--- a/examples/python-scripts/README.md
+++ b/examples/python-scripts/README.md
@@ -23,6 +23,7 @@ This only needs to be done **once**, not every time you want to run the script.
 
 In a first terminal, run:
    ```shell
+   nix develop
    mise run sim
    ```
 
@@ -30,6 +31,7 @@ In a first terminal, run:
 
 In a second terminal, type the following command:
    ```shell
+   nix develop
    python3 spawn_ships.py
    ```
 

--- a/systems/physics_engine_interface/src/physics_interface_plugin.cpp
+++ b/systems/physics_engine_interface/src/physics_interface_plugin.cpp
@@ -294,11 +294,13 @@ void PhysicsInterfacePlugin::createDomainInterface(
     std::unordered_map<gz::sim::Entity, std::shared_ptr<PhysicsInterfaceBase>>&
         _interface_map)
 {
-    InterfaceType interface_type;
-    if (!_physics_sdf->HasElement("connection_type") ||
+    // Unknown rather than uninitialised: a domain block declaring neither
+    // spelling must not reach createInterface with an arbitrary value.
+    InterfaceType interface_type = InterfaceType::Unknown;
+    if (!_physics_sdf->HasElement("connection_type") &&
         !_physics_sdf->HasElement("interface_type")) {
         m_logger->warn(
-            "PhysicsInterfacePlugin::createDomainInterface: {} missing {} interface_type or uri.",
+            "PhysicsInterfacePlugin::createDomainInterface: {} missing {} interface_type.",
             _vessel_name,
             DomainTypeToStringMap[_domain]);
     }

--- a/systems/physics_engine_interface/src/xdyn_websocket.cpp
+++ b/systems/physics_engine_interface/src/xdyn_websocket.cpp
@@ -117,17 +117,21 @@ bool XdynWebsocket::configureInterface(
     }
     m_uri[_entity][domain_type] = uri;
 
-    if (_sdf->HasElement("thrusters") && m_models_cmd_map_ptr) {
+    // The emptiness check is not redundant: a model with no thruster still has
+    // the tag, just with no child, and the loop below dereferences that child
+    // before testing it.
+    if (m_models_cmd_map_ptr && _sdf->HasElement("thrusters") &&
+        _sdf->GetElement("thrusters")->GetFirstElement()) {
         auto sdfPtr_thruster = _sdf->GetElement("thrusters")->GetFirstElement();
         auto thrusters_cmd = json::object();
-        do {
+        while (sdfPtr_thruster != sdf::ElementPtr(nullptr)) {
             std::string thruster_name = sdfPtr_thruster->Get<std::string>();
             thrusters_cmd[thruster_name + "(rpm)"] =
                 50.0;  // was 2.0 but crashes the Wageningen propeller
             thrusters_cmd[thruster_name + "(P/D)"] = 0.79;
             thrusters_cmd[thruster_name + "(beta)"] = 0.0;
             sdfPtr_thruster = sdfPtr_thruster->GetNextElement();
-        } while (sdfPtr_thruster != sdf::ElementPtr(nullptr));
+        }
         (*m_models_cmd_map_ptr)[_entity] = thrusters_cmd.dump();
     }
     return true;

--- a/systems/physics_engine_interface/src/xdyn_websocket.cpp
+++ b/systems/physics_engine_interface/src/xdyn_websocket.cpp
@@ -309,10 +309,40 @@ void XdynWebsocket::onMessage(
     websocketpp::connection_hdl hdl,
     websocketpp::config::asio_client::message_type::ptr msg)
 {
-    gz::sim::Entity entity =
-        m_connection_entity_mapping[m_client.get_con_from_hdl(hdl)];
+    gz::sim::Entity entity = m_connection_entity_mapping[m_client.get_con_from_hdl(hdl)];
+    
+    json reply;
+    try {
+        reply = json::parse(msg->get_payload());
+    } catch (const json::parse_error& e) {
+        m_logger->error("XdynWebsocket::onMessage: Failed to parse xdyn reply: {}", e.what());
+        return;
+    }
+
+    if (reply.contains("error")) {
+        m_logger->error(
+            "XdynWebsocket::onMessage: xdyn reported an error for entity {}: {}",
+            entity,
+            reply["error"].get<std::string>());
+        return;
+    }
+
+    // if xdyn can't simulate, it now logs and skip instead of crashing the websocket thread
+    static const std::vector<std::string> required_fields = {
+        "x", "y", "z", "qi", "qj", "qk", "qr",
+        "u", "v", "w", "p", "q", "r", "t"};
+    for (const auto& field : required_fields) {
+        if (!reply.contains(field) || reply[field].empty()) {
+            m_logger->error(
+                "XdynWebsocket::onMessage: Malformed reply from xdyn for entity {}, missing or empty field '{}'. Skipping update.\nRaw reply: {}",
+                entity,
+                field,
+                reply.dump());
+            return;
+        }
+    }
+
     std::unique_lock<std::mutex> lock(m_msg_mutex[entity]);
-    json reply = json::parse(msg->get_payload());
 
     auto ned_position = gz::math::Vector3d(
         reply["x"].back().get<double>(),


### PR DESCRIPTION
`configureInterface()` previously did not check if a model with a `<thrusters>` tag was correctly created. A model with an empty `<thrusters>` tag (no children) would cause `GetFirstElement()` to return `nullptr`, which was then crashing on spawn.

Fix
1. IRL CROSSING's fix 
Adds a check that the `<thrusters>` tag actually has at least one child before entering the loop, and skips entirely when there are no thruster children. Resolves the spawn crash.
Their commit is kept in this PR.

2. Follow-up fix found during testing
When testing IRL CROSSING's fix with `controlling_ship.py` example (spawning a vessel with an empty `<thrusters>` tag), it crashed LOTUSim. With no thruster command sent, xdyn returns an `"error"`.  And onMessage()` had no validation on the reply shape and this threw an uncaught exception on the websocket thread and crashed LOTUSim.
This PR adds a try/catch for malformed json, a check for xdyn's error field with the logged error, and a fallback check that all expected state fields are present before parsing.

Now, a vessel spawned with empty thrusters no longer crashes LOTUSim. It logs the xdyn error and skips the physics update for that entity until a valid reply is received.