### PR TITLE
domain transition fix to resolves the connection-reuse bug

### DIFF
--- a/assets/models/bluerov2_heavy/BlueROV2_current_none.yml
+++ b/assets/models/bluerov2_heavy/BlueROV2_current_none.yml
@@ -1,0 +1,252 @@
+rotations convention: [psi, theta', phi'']
+
+environmental constants:
+    g: {value: 9.81, unit: m/s^2}
+    rho: {value: 1000, unit: kg/m^3}
+    nu: {value: 1.18e-6, unit: m^2/s}
+
+bodies: # All bodies have NED as parent frame
+  - name: bluerov2_heavy
+    position of body frame relative to mesh:
+        frame: mesh
+        x: {value: 0.20, unit: m}
+        y: {value: 0.0, unit: m}
+        z: {value: -0.100, unit: m}
+        phi: {value: 0, unit: rad}
+        theta: {value: 0, unit: rad}
+        psi: {value: 0, unit: rad}
+    dynamics:
+        hydrodynamic forces calculation point in body frame:
+            x: {value: 0, unit: m}
+            y: {value: 0, unit: m}
+            z: {value: 0., unit: m}
+        centre of inertia:
+            frame: bluerov2_heavy
+            x: {value: 0, unit: m}
+            y: {value: 0, unit: m}
+            z: {value: 0, unit: m}
+        mass: {value: 13.5, unit: kg} # Caution: 'ton' is the british ton which is 907.185 kg
+        rigid body inertia matrix at the center of gravity and projected in the body frame:
+            convention z down: false
+            frame: bluerov2_heavy
+            row 1: [13.5, 0.00, 0.00, 0.00, 0.00, 0.00]
+            row 2: [0.00, 13.5, 0.00, 0.00, 0.00, 0.00]
+            row 3: [0.00, 0.00, 13.5, 0.00, 0.00, 0.00]
+            row 4: [0.00, 0.00, 0.00, 0.26, 0.00, 0.00] # JMSE
+            row 5: [0.00, 0.00, 0.00, 0.00, 0.23, 0.00] # JMSE
+            row 6: [0.00, 0.00, 0.00, 0.00, 0.00, 0.37] # JMSE
+        added mass matrix at the center of gravity and projected in the body frame:
+            convention z down: false
+            frame: bluerov2_heavy
+            # JMSE, citing Eidsvik
+            row 1: [6.360, 0.000, 0.000, 0.000, 0.000, 0.000]
+            row 2: [0.000, 7.120, 0.000, 0.000, 0.000, 0.000]
+            row 3: [0.000, 0.000, 18.68, 0.000, 0.000, 0.000]
+            row 4: [0.000, 0.000, 0.000, 0.189, 0.000, 0.000]
+            row 5: [0.000, 0.000, 0.000, 0.000, 0.135, 0.000]
+            row 6: [0.000, 0.000, 0.000, 0.000, 0.000, 0.222]
+    initial position of body frame relative to NED:
+        frame: NED
+        x: {value: 0, unit: m}
+        y: {value: 0, unit: m}
+        z: {value: 2, unit: m}
+        phi: {value: 0, unit: deg}
+        theta: {value: 0, unit: deg}
+        psi: {value: 0, unit: deg}
+    initial velocity of body frame relative to NED:
+        frame: bluerov2_heavy
+        u: {value: 0, unit: m/s}
+        v: {value: 0, unit: m/s}
+        w: {value: 0, unit: m/s}
+        p: {value: 0, unit: rad/s}
+        q: {value: 0, unit: rad/s}
+        r: {value: 0, unit: rad/s}
+    external forces:
+      - model: linear damping
+        damping matrix at the center of gravity projected in the body frame:
+            convention z down: false
+            frame: bluerov2_heavy
+            row 1: [13.7, 0.00, 0.00, 0.00, 0.00, 0.00]
+            row 2: [0.00, 0.00, 0.00, 0.00, 0.00, 0.00]
+            row 3: [0.00, 0.00, 33.0, 0.00, 0.00, 0.00]
+            row 4: [0.00, 0.00, 0.00, 0.00, 0.00, 0.00]
+            row 5: [0.00, 0.00, 0.00, 0.00, 0.80, 0.00]
+            row 6: [0.00, 0.00, 0.00, 0.00, 0.00, 0.00]
+      - model: quadratic damping
+        damping matrix at the center of gravity projected in the body frame:
+            convention z down: false
+            frame: bluerov2_heavy
+            row 1: [141.0, 0.000, 0.000, 0.000, 0.000, 0.000]
+            row 2: [0.000, 217.0, 0.000, 0.000, 0.000, 0.000]
+            row 3: [0.000, 0.000, 190.0, 0.000, 0.000, 0.000]
+            row 4: [0.000, 0.000, 0.000, 1.190, 0.000, 0.000]
+            row 5: [0.000, 0.000, 0.000, 0.000, 0.470, 0.000]
+            row 6: [0.000, 0.000, 0.000, 0.000, 0.000, 1.500]
+
+      # --- Weight + buoyancy (Fossen) ----------------------------------------
+      # Applied force = -g(eta). W-B = +0.98 N: the vehicle is slightly heavy,
+      # it sinks at w = +0.026 m/s, and pitch returns to zero.
+      - model: maneuvering
+        name: bluerov2_heavy_man
+        reference frame:
+            frame: bluerov2_heavy
+            x: {value: 0, unit: m}
+            y: {value: 0, unit: m}
+            z: {value: 0, unit: m}
+            phi: {value: 0, unit: deg}
+            theta: {value: 0, unit: deg}
+            psi: {value: 0, unit: deg}
+        X: (-1)*(W-B)*sin(theta(t))
+        Y: (W-B) * cos(theta(t)) * sin(phi(t))
+        Z: (W-B) * cos(theta(t)) * cos(phi(t))
+        K: (-1)*(yb * B * cos(theta(t)) * cos(phi(t)) - zb * B * cos(theta(t)) * sin(phi(t)))
+        M: zb * B * sin(theta(t)) + xb * B * cos(theta(t)) * cos(phi(t))
+        N: (-1)*(xb * B * cos(theta(t)) * sin(phi(t)) + yb * B * sin(theta(t)))
+        nabla: 0.0134
+        W: 13.5 * g
+        B : rho * g * nabla
+        xb: 0
+        yb: 0
+        zb: -0.01
+
+      # --- Vectored thrusters (horizontal plane), z = 0 (centre of gravity) --
+      # Decoupled command patterns (see src/pid.py, ThrusterAllocator):
+      #   surge X : [+1, +1, -1, -1] -> X = +2.828 * T
+      #   sway  Y : [+1, -1, +1, -1] -> Y = -2.828 * T
+      #   yaw   N : [+1, -1, -1, +1] -> N = -0.127 * T
+      - model: maneuvering
+        name: bluerov2_heavy_prop_1
+        reference frame:
+            frame: bluerov2_heavy
+            x: {value: 0.156, unit: m}
+            y: {value: -0.111, unit: m}
+            z: {value: 0.0, unit: m}
+            phi: {value: 0, unit: deg}
+            theta: {value: 0, unit: deg}
+            psi: {value: 0, unit: deg}
+        commands: [T]
+        X: X_imm
+        Y: Y_imm
+        Z: Z_imm
+        K: 0
+        M: 0
+        N: 0
+
+        X_imm: 0.7071 * T
+        Y_imm: -0.7071 * T
+        Z_imm: 0.0 * T
+      - model: maneuvering
+        name: bluerov2_heavy_prop_2
+        reference frame:
+            frame: bluerov2_heavy
+            x: {value: 0.156, unit: m}
+            y: {value: 0.111, unit: m}
+            z: {value: 0.0, unit: m}
+            phi: {value: 0, unit: deg}
+            theta: {value: 0, unit: deg}
+            psi: {value: 0, unit: deg}
+        commands: [T]
+        X: X_imm
+        Y: Y_imm
+        Z: Z_imm
+        K: 0
+        M: 0
+        N: 0
+
+        X_imm: 0.7071 * T
+        Y_imm: 0.7071 * T
+        Z_imm: 0.0 * T
+      - model: maneuvering
+        name: bluerov2_heavy_prop_3
+        reference frame:
+            frame: bluerov2_heavy
+            x: {value: -0.156, unit: m}
+            y: {value: -0.111, unit: m}
+            z: {value: 0.0, unit: m}
+            phi: {value: 0, unit: deg}
+            theta: {value: 0, unit: deg}
+            psi: {value: 0, unit: deg}
+        commands: [T]
+        X: X_imm
+        Y: Y_imm
+        Z: Z_imm
+        K: 0
+        M: 0
+        N: 0
+
+        X_imm: -0.7071 * T
+        Y_imm: -0.7071 * T
+        Z_imm: 0.0 * T
+      - model: maneuvering
+        name: bluerov2_heavy_prop_4
+        reference frame:
+            frame: bluerov2_heavy
+            x: {value: -0.156, unit: m}
+            y: {value: 0.111, unit: m}
+            z: {value: 0.0, unit: m}
+            phi: {value: 0, unit: deg}
+            theta: {value: 0, unit: deg}
+            psi: {value: 0, unit: deg}
+        commands: [T]
+        X: X_imm
+        Y: Y_imm
+        Z: Z_imm
+        K: 0
+        M: 0
+        N: 0
+
+        X_imm: -0.7071 * T
+        Y_imm: 0.7071 * T
+        Z_imm: 0.0 * T
+
+      # --- Vertical thrusters (diagonal pair 5/8) ---------------------------
+      # Z = -(T5 + T8): a negative T makes the vehicle go down (positive Z is
+      # downwards in NED). 6 and 7 are not modelled.
+      - model: maneuvering
+        name: bluerov2_heavy_prop_5
+        reference frame:
+            frame: bluerov2_heavy
+            x: {value: 0.12, unit: m}
+            y: {value: 0.218, unit: m}
+            z: {value: 0.0, unit: m}
+            phi: {value: 0, unit: deg}
+            theta: {value: 0, unit: deg}
+            psi: {value: 0, unit: deg}
+        commands: [T]
+        X: X_imm
+        Y: Y_imm
+        Z: Z_imm
+        K: 0
+        M: 0
+        N: 0
+
+        X_imm: 0.0 * T
+        Y_imm: 0.0 * T
+        Z_imm: -1.0 * T
+      - model: maneuvering
+        name: bluerov2_heavy_prop_8
+        reference frame:
+            frame: bluerov2_heavy
+            x: {value: -0.12, unit: m}
+            y: {value: -0.218, unit: m}
+            z: {value: 0.0, unit: m}
+            phi: {value: 0, unit: deg}
+            theta: {value: 0, unit: deg}
+            psi: {value: 0, unit: deg}
+        commands: [T]
+        X: X_imm
+        Y: Y_imm
+        Z: Z_imm
+        K: 0
+        M: 0
+        N: 0
+
+        X_imm: 0.0 * T
+        Y_imm: 0.0 * T
+        Z_imm: -1.0 * T
+
+# Reference environment: flat sea, no current.
+# Control condition against env_ekman.yml.
+environment models:
+  - model: no waves
+    constant sea elevation in NED frame: {value: 0, unit: m}

--- a/examples/python-scripts/climb_test.py
+++ b/examples/python-scripts/climb_test.py
@@ -11,44 +11,44 @@ from lotusim_msgs.msg import VesselCmd, VesselCmdArray, VesselPositionArray
 from lotusim_msgs.msg import MASCmd as MASCmdMsg
 from lotusim_msgs.action import MASCmd, MASCmdArray
 
-SPAWN_LATITUDE = 1.2605794416293148
-SPAWN_LONGITUDE = 103.7516212463379
-# Domain thresholds in getNewState are z <= -10.0 (Underwater) and z >= 10.0 (Aerial); in between is Surface.
-SPAWN_ALTITUDE = -1.0
+# positive climbs, negative sinks
+CLIMB_THRUST = 8.0
+DIVE_THRUST = -8.0
+# how often to flip direction
+FLIP_PERIOD_SEC = 4.0
+SPAWN_Z = -10.0
 
-
-class ClimbTestNode(Node):
+class OscillateTestNode(Node):
     def __init__(self):
-        super().__init__('climb_test_node')
-        self.pose_subscription = self.create_subscription(
-            VesselPositionArray,
-            '/lotusim/poses',
-            self.poses_callback,
-            10
-        )
+        super().__init__('oscillate_test_node')
+        self.pose_subscription = self.create_subscription(VesselPositionArray, '/lotusim/poses', self.poses_callback, 10)
         self.vessel_poses = {}
         self.last_pose_time = {}
         self.spawned_vessels = []
 
-        self.cmd_publisher = self.create_publisher(
-            VesselCmdArray,
-            '/lotusim/vessel_cmd_array',
-            10
-        )
+        self.cmd_publisher = self.create_publisher(VesselCmdArray, '/lotusim/vessel_cmd_array', 10)
         self.mas_action_client = ActionClient(self, MASCmd, '/lotusim/mas_cmd')
 
         self.rpm_publisher = {}
         self.position_timer = self.create_timer(1.0, self.print_vessel_positions)
         self.vessel_id = 0
 
+        self.current_thrust = CLIMB_THRUST
+        self.direction_timer = self.create_timer(FLIP_PERIOD_SEC, self.flip_direction)
+
+    def flip_direction(self):
+        self.current_thrust = (
+            DIVE_THRUST if self.current_thrust == CLIMB_THRUST else CLIMB_THRUST
+        )
+        label = "DIVING" if self.current_thrust < 0 else "CLIMBING"
+        self.get_logger().info(f"=== Flipping direction: now {label} (thrust={self.current_thrust}) ===")
+
     def poses_callback(self, msg):
         now = time.time()
         for vessel_position in msg.vessels:
             name = vessel_position.vessel_name
-            lat = vessel_position.geo_point.latitude
-            lon = vessel_position.geo_point.longitude
-            alt = vessel_position.geo_point.altitude
-            self.vessel_poses[name] = (lat, lon, alt)
+            z = vessel_position.pose.position.z
+            self.vessel_poses[name] = z
             self.last_pose_time[name] = now
 
     def print_vessel_positions(self):
@@ -56,57 +56,62 @@ class ClimbTestNode(Node):
             self.get_logger().info("No vessel positions yet")
             return
         now = time.time()
-        for name, (lat, lon, alt) in self.vessel_poses.items():
+        for name, z in self.vessel_poses.items():
             staleness = now - self.last_pose_time.get(name, now)
-            flag = " <- Stale, check for timeout in logs" if staleness > 2.0 else ""
+            flag = " <- STALE, check for timeout in logs" if staleness > 3.0 else ""
             self.get_logger().info(
-                f"{name}: lat={lat:.6f}, lon={lon:.6f}, alt={alt:.2f} "
-                f"(last update {staleness:.1f}s ago){flag}"
+                f"{name}: z={z:.2f} (last update {staleness:.1f}s ago){flag}"
             )
 
     def spawn_ship_with_dynamics(self, vessel_name: str):
         msg = MASCmdMsg()
         msg.cmd_type = MASCmdMsg.CREATE_CMD
-        msg.model_name = "lrauv"
-        vessel_name = f"lrauv_{self.vessel_id}"
+        msg.model_name = "bluerov2_heavy"
+        vessel_name = f"bluerov2_heavy{self.vessel_id}"
         msg.vessel_name = vessel_name
 
-        geo = GeoPoint()
-        geo.latitude = SPAWN_LATITUDE
-        geo.longitude = SPAWN_LONGITUDE
-        geo.altitude = SPAWN_ALTITUDE
-        msg.geo_point = geo
+        msg.vessel_position.position.x = 0.0
+        msg.vessel_position.position.y = 0.0
+        msg.vessel_position.position.z = SPAWN_Z
+        msg.vessel_position.orientation.w = 1.0 
 
         msg.sdf_string = """
         <lotus_param>
             <render_interface>
                 <publish_render>true</publish_render>
-                <renderer_type_name>lrauv</renderer_type_name>
+                <renderer_type_name>bluerov2_heavy</renderer_type_name>
             </render_interface>
             <physics_engine_interface>
             <underwater>
                 <interface_type>XDynWebSocket</interface_type>
                 <uri>ws://127.0.0.1:12346</uri>
                 <thrusters>
-                    <thrusters1>propeller</thrusters1>
+                    <thrusters1>bluerov2_heavy_prop_1</thrusters1>
+                    <thrusters2>bluerov2_heavy_prop_2</thrusters2>
+                    <thrusters3>bluerov2_heavy_prop_3</thrusters3>
+                    <thrusters4>bluerov2_heavy_prop_4</thrusters4>
+                    <thrusters5>bluerov2_heavy_prop_5</thrusters5>
+                    <thrusters6>bluerov2_heavy_prop_8</thrusters6>
                 </thrusters>
             </underwater>
             <surface>
                 <interface_type>XDynWebSocket</interface_type>
                 <uri>ws://127.0.0.1:12345</uri>
                 <thrusters>
-                    <thrusters1>propeller</thrusters1>
+                    <thrusters1>bluerov2_heavy_prop_1</thrusters1>
+                    <thrusters2>bluerov2_heavy_prop_2</thrusters2>
+                    <thrusters3>bluerov2_heavy_prop_3</thrusters3>
+                    <thrusters4>bluerov2_heavy_prop_4</thrusters4>
+                    <thrusters5>bluerov2_heavy_prop_5</thrusters5>
+                    <thrusters6>bluerov2_heavy_prop_8</thrusters6>
                 </thrusters>
             </surface>
-            <init_state>Surface</init_state>
+            <init_state>Underwater</init_state>
             </physics_engine_interface>
         </lotus_param>
         """
 
-        self.rpm_publisher[vessel_name] = self.create_publisher(
-            Float64,
-            f'/{vessel_name}/rpm',
-            10)
+        self.rpm_publisher[vessel_name] = self.create_publisher(Float64, f'/{vessel_name}/rpm', 10)
         self.get_logger().info(f"Created RPM publisher on /{vessel_name}/rpm")
         self.vessel_id += 1
         self.spawned_vessels.append(vessel_name)
@@ -128,61 +133,52 @@ class ClimbTestNode(Node):
             msg.cmd_type = MASCmdMsg.DELETE_CMD
             msg.vessel_name = name
             goal_msg.cmd.append(msg)
-
         time.sleep(0.2)
-
         future = self.mas_array_action_client.send_goal_async(goal_msg)
         rclpy.spin_until_future_complete(self, future)
-
         goal_handle = future.result()
         if not goal_handle or not goal_handle.accepted:
             self.get_logger().error("Delete goal rejected")
             return
-        
         result_future = goal_handle.get_result_async()
         rclpy.spin_until_future_complete(self, result_future)
         self.get_logger().info("All vessels deleted")
         self.spawned_vessels.clear()
 
-    def send_propeller_command(self, vessel_name: str, rpm: float, pd: float):
+    def send_dive_command(self, vessel_name: str, thrust: float):
         cmd_array = VesselCmdArray()
         cmd = VesselCmd()
         cmd.vessel_name = vessel_name
-        cmd.cmd_string = json.dumps({"propeller(rpm)": rpm, "propeller(P/D)": pd})
+        cmd.cmd_string = json.dumps({
+            "bluerov2_heavy_prop_1(T)": 0.0,
+            "bluerov2_heavy_prop_2(T)": 0.0,
+            "bluerov2_heavy_prop_3(T)": 0.0,
+            "bluerov2_heavy_prop_4(T)": 0.0,
+            "bluerov2_heavy_prop_5(T)": thrust,
+            "bluerov2_heavy_prop_8(T)": thrust,
+        })
         cmd_array.cmds.append(cmd)
         self.cmd_publisher.publish(cmd_array)
-
-        if vessel_name in self.rpm_publisher:
-            rpm_msg = Float64()
-            rpm_msg.data = rpm
-            self.rpm_publisher[vessel_name].publish(rpm_msg)
-
-        self.get_logger().info(
-            f"{vessel_name} - propeller command: rpm={rpm}, P/D={pd}")
 
 
 def main(args=None):
     rclpy.init(args=args)
-    node = ClimbTestNode()
+    node = OscillateTestNode()
 
-    vessel_name = "lrauv_0"
+    vessel_name = "bluerov2_heavy_0"
     future = node.spawn_ship_with_dynamics(vessel_name)
     rclpy.spin_until_future_complete(node, future)
     goal_handle = future.result()
     result_future = goal_handle.get_result_async()
     rclpy.spin_until_future_complete(node, result_future)
     vessel_name = result_future.result().result.name
-    node.get_logger().info(f"Spawn request sent successfully, vessel name: {vessel_name}")
 
     time.sleep(1.0)
 
-    # Positive pitch (P/D) + steady rpm to climb from -12.0 up through the
-    # -10.0 Underwater/Surface boundary. Adjust rpm/pd if it doesn't climb
-    # fast enough (or climbs too fast to observe) in your build.
     def send_timer_callback():
-        node.send_propeller_command(vessel_name, 200.0, 0.88)
+        node.send_dive_command(vessel_name, node.current_thrust)
 
-    node.create_timer(0.5, send_timer_callback)
+    node.create_timer(0.2, send_timer_callback)
     rclpy.spin_once(node)
 
     shutdown_requested = False
@@ -193,12 +189,6 @@ def main(args=None):
 
     signal.signal(signal.SIGINT, signal_handler)
     signal.signal(signal.SIGTERM, signal_handler)
-
-    node.get_logger().info(
-        f"Watching for domain transition around z=-10.0 (spawned at {SPAWN_ALTITUDE}). "
-        "Watch this log for 'STALE' and the LOTUSim terminal for "
-        "'websocket timed out' after the transition."
-    )
 
     try:
         while rclpy.ok() and not shutdown_requested:

--- a/examples/python-scripts/climb_test.py
+++ b/examples/python-scripts/climb_test.py
@@ -1,0 +1,215 @@
+import json
+import time
+import signal
+
+import rclpy
+from rclpy.node import Node
+from rclpy.action import ActionClient
+from std_msgs.msg import Float64
+from geographic_msgs.msg import GeoPoint
+from lotusim_msgs.msg import VesselCmd, VesselCmdArray, VesselPositionArray
+from lotusim_msgs.msg import MASCmd as MASCmdMsg
+from lotusim_msgs.action import MASCmd, MASCmdArray
+
+SPAWN_LATITUDE = 1.2605794416293148
+SPAWN_LONGITUDE = 103.7516212463379
+# Domain thresholds in getNewState are z <= -10.0 (Underwater) and z >= 10.0 (Aerial); in between is Surface.
+SPAWN_ALTITUDE = -1.0
+
+
+class ClimbTestNode(Node):
+    def __init__(self):
+        super().__init__('climb_test_node')
+        self.pose_subscription = self.create_subscription(
+            VesselPositionArray,
+            '/lotusim/poses',
+            self.poses_callback,
+            10
+        )
+        self.vessel_poses = {}
+        self.last_pose_time = {}
+        self.spawned_vessels = []
+
+        self.cmd_publisher = self.create_publisher(
+            VesselCmdArray,
+            '/lotusim/vessel_cmd_array',
+            10
+        )
+        self.mas_action_client = ActionClient(self, MASCmd, '/lotusim/mas_cmd')
+
+        self.rpm_publisher = {}
+        self.position_timer = self.create_timer(1.0, self.print_vessel_positions)
+        self.vessel_id = 0
+
+    def poses_callback(self, msg):
+        now = time.time()
+        for vessel_position in msg.vessels:
+            name = vessel_position.vessel_name
+            lat = vessel_position.geo_point.latitude
+            lon = vessel_position.geo_point.longitude
+            alt = vessel_position.geo_point.altitude
+            self.vessel_poses[name] = (lat, lon, alt)
+            self.last_pose_time[name] = now
+
+    def print_vessel_positions(self):
+        if not self.vessel_poses:
+            self.get_logger().info("No vessel positions yet")
+            return
+        now = time.time()
+        for name, (lat, lon, alt) in self.vessel_poses.items():
+            staleness = now - self.last_pose_time.get(name, now)
+            flag = " <- Stale, check for timeout in logs" if staleness > 2.0 else ""
+            self.get_logger().info(
+                f"{name}: lat={lat:.6f}, lon={lon:.6f}, alt={alt:.2f} "
+                f"(last update {staleness:.1f}s ago){flag}"
+            )
+
+    def spawn_ship_with_dynamics(self, vessel_name: str):
+        msg = MASCmdMsg()
+        msg.cmd_type = MASCmdMsg.CREATE_CMD
+        msg.model_name = "lrauv"
+        vessel_name = f"lrauv_{self.vessel_id}"
+        msg.vessel_name = vessel_name
+
+        geo = GeoPoint()
+        geo.latitude = SPAWN_LATITUDE
+        geo.longitude = SPAWN_LONGITUDE
+        geo.altitude = SPAWN_ALTITUDE
+        msg.geo_point = geo
+
+        msg.sdf_string = """
+        <lotus_param>
+            <render_interface>
+                <publish_render>true</publish_render>
+                <renderer_type_name>lrauv</renderer_type_name>
+            </render_interface>
+            <physics_engine_interface>
+            <underwater>
+                <interface_type>XDynWebSocket</interface_type>
+                <uri>ws://127.0.0.1:12346</uri>
+                <thrusters>
+                    <thrusters1>propeller</thrusters1>
+                </thrusters>
+            </underwater>
+            <surface>
+                <interface_type>XDynWebSocket</interface_type>
+                <uri>ws://127.0.0.1:12345</uri>
+                <thrusters>
+                    <thrusters1>propeller</thrusters1>
+                </thrusters>
+            </surface>
+            <init_state>Surface</init_state>
+            </physics_engine_interface>
+        </lotus_param>
+        """
+
+        self.rpm_publisher[vessel_name] = self.create_publisher(
+            Float64,
+            f'/{vessel_name}/rpm',
+            10)
+        self.get_logger().info(f"Created RPM publisher on /{vessel_name}/rpm")
+        self.vessel_id += 1
+        self.spawned_vessels.append(vessel_name)
+
+        goal_msg = MASCmd.Goal()
+        goal_msg.cmd = msg
+        self.mas_action_client.wait_for_server()
+        return self.mas_action_client.send_goal_async(goal_msg)
+
+    def delete_all_vessels(self):
+        if not self.spawned_vessels:
+            return
+        if not self.mas_array_action_client.wait_for_server(timeout_sec=2.0):
+            self.get_logger().warn("Action server not available for cleanup")
+            return
+        goal_msg = MASCmdArray.Goal()
+        for name in self.spawned_vessels:
+            msg = MASCmdMsg()
+            msg.cmd_type = MASCmdMsg.DELETE_CMD
+            msg.vessel_name = name
+            goal_msg.cmd.append(msg)
+
+        time.sleep(0.2)
+
+        future = self.mas_array_action_client.send_goal_async(goal_msg)
+        rclpy.spin_until_future_complete(self, future)
+
+        goal_handle = future.result()
+        if not goal_handle or not goal_handle.accepted:
+            self.get_logger().error("Delete goal rejected")
+            return
+        
+        result_future = goal_handle.get_result_async()
+        rclpy.spin_until_future_complete(self, result_future)
+        self.get_logger().info("All vessels deleted")
+        self.spawned_vessels.clear()
+
+    def send_propeller_command(self, vessel_name: str, rpm: float, pd: float):
+        cmd_array = VesselCmdArray()
+        cmd = VesselCmd()
+        cmd.vessel_name = vessel_name
+        cmd.cmd_string = json.dumps({"propeller(rpm)": rpm, "propeller(P/D)": pd})
+        cmd_array.cmds.append(cmd)
+        self.cmd_publisher.publish(cmd_array)
+
+        if vessel_name in self.rpm_publisher:
+            rpm_msg = Float64()
+            rpm_msg.data = rpm
+            self.rpm_publisher[vessel_name].publish(rpm_msg)
+
+        self.get_logger().info(
+            f"{vessel_name} - propeller command: rpm={rpm}, P/D={pd}")
+
+
+def main(args=None):
+    rclpy.init(args=args)
+    node = ClimbTestNode()
+
+    vessel_name = "lrauv_0"
+    future = node.spawn_ship_with_dynamics(vessel_name)
+    rclpy.spin_until_future_complete(node, future)
+    goal_handle = future.result()
+    result_future = goal_handle.get_result_async()
+    rclpy.spin_until_future_complete(node, result_future)
+    vessel_name = result_future.result().result.name
+    node.get_logger().info(f"Spawn request sent successfully, vessel name: {vessel_name}")
+
+    time.sleep(1.0)
+
+    # Positive pitch (P/D) + steady rpm to climb from -12.0 up through the
+    # -10.0 Underwater/Surface boundary. Adjust rpm/pd if it doesn't climb
+    # fast enough (or climbs too fast to observe) in your build.
+    def send_timer_callback():
+        node.send_propeller_command(vessel_name, 200.0, 0.88)
+
+    node.create_timer(0.5, send_timer_callback)
+    rclpy.spin_once(node)
+
+    shutdown_requested = False
+
+    def signal_handler(sig, frame):
+        nonlocal shutdown_requested
+        shutdown_requested = True
+
+    signal.signal(signal.SIGINT, signal_handler)
+    signal.signal(signal.SIGTERM, signal_handler)
+
+    node.get_logger().info(
+        f"Watching for domain transition around z=-10.0 (spawned at {SPAWN_ALTITUDE}). "
+        "Watch this log for 'STALE' and the LOTUSim terminal for "
+        "'websocket timed out' after the transition."
+    )
+
+    try:
+        while rclpy.ok() and not shutdown_requested:
+            rclpy.spin_once(node, timeout_sec=0.1)
+    finally:
+        node.get_logger().info("Shutting down, deleting vessels...")
+        node.delete_all_vessels()
+        node.destroy_node()
+        if rclpy.ok():
+            rclpy.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/systems/physics_engine_interface/src/physics_interface_plugin.cpp
+++ b/systems/physics_engine_interface/src/physics_interface_plugin.cpp
@@ -405,7 +405,16 @@ bool PhysicsInterfacePlugin::vesselDomainTransition(
     }
 
     std::unique_lock<std::shared_mutex> lock(m_mutex);
+    // Only tear the previous interface down when it is a DIFFERENT object from
+    // the one just activated. XdynWebsocket is a singleton: the surface and
+    // underwater interfaces of an xdyn model are the same instance, and its
+    // connections are keyed by entity alone, not by (entity, domain). For a
+    // model crossing its surface threshold, activateInterface reused the
+    // connection already open, and deactivating "the previous interface" here
+    // closes that same connection, leaving the model with none for every step
+    // that follows.
     if (m_vehicle_current_mode.find(_vessel) != m_vehicle_current_mode.end() &&
+        m_current_vessel_interface[_vessel] != new_interface &&
         !m_current_vessel_interface[_vessel]->deactivateInterface(
             _vessel,
             m_vehicle_current_mode[_vessel])) {


### PR DESCRIPTION
IRL CROSSING fix: 
From their branch fix/domain-transition-singleton
`XdynWebsocket` is a singleton, so a vessel's Surface and Underwater interfaces are the same object with connections keyed by entity alone. The previous code deactivated "the previous interface" after a domain transition, which, for models sharing this singleton across domains, tore down the connection `activateInterface` had just opened, leaving the vessel with no live connection from that point on.

What I tested:
Tested this fix with a scenario it describes: a vessel whose Surface and Underwater interfaces both use `XDynWebSocket`, transitioning between domains. Confirmed the fix prevents a  `deactivateInterface` call from tearing down the just-activated connection.
I used the  `BlueROV2_current_none.yml` model from IRL CROSSING, which has two dedicated vertical thrusters. And developed a `climb_test.py` which spawns the bluerov at `z = -10.0` (domain threshold) and quickly switches thrust direction every few seconds. It forcing repeated Underwater <-> Surface crossings.

With the fix, I get one clean `deactivateInterface` call per transition, followed immediately by `activateInterface` opening the new domain's connection. No stale/duplicate calls, no gaps in `/lotusim/poses` updates, no `websocket timed out`  warnings.

Without the fix, I get the exact faulty call IRL CROSSING described: a second `deactivateInterface` call fires after `activateInterface` has already succeeded and switched `m_current_domain`.