### PR TITLE
fix: create the MASCmdArray client controlling_ships deletes through

### DIFF
--- a/examples/python-scripts/controlling_ships.py
+++ b/examples/python-scripts/controlling_ships.py
@@ -35,6 +35,11 @@ class ExampleNode(Node):
             10
         )
         self.mas_action_client = ActionClient(self, MASCmd, '/lotusim/mas_cmd')
+        self.mas_array_action_client = ActionClient(
+            self,
+            MASCmdArray,
+            '/lotusim/mas_cmd_array'
+        )
 
         self.rpm_publisher = {}
         self.position_timer = self.create_timer(1.0, self.print_vessel_positions)


### PR DESCRIPTION
delete_all_vessels sends its goal on mas_array_action_client, which the node never created, so leaving the example raised AttributeError instead of removing the vessels it spawned.