### PR TITLE
IRL CROSSING ECM thread safety fix + replaced xdyn's blind wait for activateInterface

### DIFF
--- a/systems/physics_engine_interface/include/physics_engine_interface/physics_interface_plugin.hpp
+++ b/systems/physics_engine_interface/include/physics_engine_interface/physics_interface_plugin.hpp
@@ -229,6 +229,15 @@ private:
     mutable std::shared_mutex m_mutex;
 
     /**
+     * @brief Serialises EntityComponentManager access.
+     *
+     * The ECM is not thread-safe and the per-model updates run concurrently,
+     * so its reads and writes are taken under this lock while the physics step
+     * itself stays parallel.
+     */
+    std::mutex m_ecm_mutex;
+
+    /**
      * @brief List of the vessel entities
      *
      */

--- a/systems/physics_engine_interface/src/physics_interface_plugin.cpp
+++ b/systems/physics_engine_interface/src/physics_interface_plugin.cpp
@@ -157,6 +157,10 @@ void PhysicsInterfacePlugin::updateVesselState(
         gz::math::Vector3d lin_vel;
         gz::math::Vector3d ang_vel;
         std::string vessel_name;
+        gz::sim::Entity base_link_entity;
+        std::shared_ptr<PhysicsInterfaceBase> interface;
+
+        // Resolve the mappings (concurrent reads are safe under shared lock).
         {
             std::shared_lock<std::shared_mutex> lock(m_mutex);
             auto it_name = m_vessels_name_map.find(vessel_entity);
@@ -168,24 +172,6 @@ void PhysicsInterfacePlugin::updateVesselState(
             }
             vessel_name = it_name->second;
 
-            float target_time =
-                std::chrono::duration_cast<std::chrono::milliseconds>(_info.dt)
-                    .count();
-
-            std::chrono::_V2::system_clock::time_point start_time =
-                std::chrono::system_clock::now();
-
-            auto pose_comp =
-                _ecm.Component<gz::sim::components::Pose>(vessel_entity);
-            if (pose_comp) {
-                pose = pose_comp->Data();
-            } else {
-                m_logger->error(
-                    "PhysicsInterfacePlugin::updateVesselState: unable to get pose component for {}",
-                    vessel_name);
-                return;
-            }
-
             auto it_base = m_vessels_base_link_map.find(vessel_name);
             if (it_base == m_vessels_base_link_map.end()) {
                 m_logger->error(
@@ -193,13 +179,45 @@ void PhysicsInterfacePlugin::updateVesselState(
                     vessel_name);
                 return;
             }
-            gz::sim::Link _link(it_base->second);
+            base_link_entity = it_base->second;
 
-            // Get the linear and angular velocity in world frame, ENU.
+            auto it_interface = m_current_vessel_interface.find(vessel_entity);
+            if (it_interface == m_current_vessel_interface.end() ||
+                !it_interface->second) {
+                m_logger->error(
+                    "PhysicsInterfacePlugin::updateVesselState: No physics interface found for vessel {}",
+                    vessel_name);
+                return;
+            }
+            interface = it_interface->second;
+        }
+
+        const float target_time =
+            std::chrono::duration_cast<std::chrono::milliseconds>(_info.dt)
+                .count();
+        const std::chrono::_V2::system_clock::time_point start_time =
+            std::chrono::system_clock::now();
+
+        // Phase 1: read the state from the ECM (serialised, ECM not
+        // thread-safe).
+        VesselInformation vessel_info;
+        {
+            std::lock_guard<std::mutex> ecm_lock(m_ecm_mutex);
+            auto pose_comp =
+                _ecm.Component<gz::sim::components::Pose>(vessel_entity);
+            if (!pose_comp) {
+                m_logger->error(
+                    "PhysicsInterfacePlugin::updateVesselState: unable to get pose component for {}",
+                    vessel_name);
+                return;
+            }
+            pose = pose_comp->Data();
+
+            gz::sim::Link _link(base_link_entity);
+            // World frame, ENU.
             auto lin_vel_opt = _link.WorldLinearVelocity(_ecm);
             auto ang_vel_opt = _link.WorldAngularVelocity(_ecm);
 
-            VesselInformation vessel_info;
             vessel_info.time =
                 std::chrono::duration_cast<std::chrono::milliseconds>(
                     _info.simTime)
@@ -213,31 +231,23 @@ void PhysicsInterfacePlugin::updateVesselState(
             }
             vessel_info.entity = vessel_entity;
             vessel_info.pose = pose;
-
-            auto it_interface = m_current_vessel_interface.find(vessel_entity);
-            if (it_interface == m_current_vessel_interface.end() ||
-                !it_interface->second) {
-                m_logger->error(
-                    "PhysicsInterfacePlugin::updateVesselState: No physics interface found for vessel {}",
-                    vessel_name);
-                return;
-            }
-
-            update_opt = it_interface->second->getNewState(
-                vessel_entity,
-                vessel_info,
-                target_time);
-
-            // Print physics engine response time if compiled in debug mode
-            if (m_logger->level() < spdlog::level::info) {
-                m_logger->debug(
-                    "PhysicsInterfacePlugin::updateVesselState: {} Phyiscs update time: {}",
-                    vessel_name,
-                    std::chrono::duration_cast<std::chrono::milliseconds>(
-                        std::chrono::system_clock::now() - start_time)
-                        .count());
-            }
         }
+
+        // Phase 2: compute the new state (runs in parallel, no ECM access).
+        update_opt =
+            interface->getNewState(vessel_entity, vessel_info, target_time);
+
+        // Print physics engine response time if compiled in debug mode
+        if (m_logger->level() < spdlog::level::info) {
+            m_logger->debug(
+                "PhysicsInterfacePlugin::updateVesselState: {} Phyiscs update time: {}",
+                vessel_name,
+                std::chrono::duration_cast<std::chrono::milliseconds>(
+                    std::chrono::system_clock::now() - start_time)
+                    .count());
+        }
+
+        // Phase 3: write the new state to the ECM (serialised).
         if (update_opt) {
             if (!vesselDomainTransition(
                     vessel_entity,
@@ -254,6 +264,7 @@ void PhysicsInterfacePlugin::updateVesselState(
             lin_vel = new_state.lin_vel;
             ang_vel = new_state.ang_vel;
 
+            std::lock_guard<std::mutex> ecm_lock(m_ecm_mutex);
             _ecm.SetComponentData<gz::sim::components::Pose>(
                 vessel_entity,
                 pose);
@@ -263,11 +274,11 @@ void PhysicsInterfacePlugin::updateVesselState(
                 gz::sim::ComponentState::OneTimeChange);
 
             _ecm.SetComponentData<gz::sim::components::WorldLinearVelocity>(
-                m_vessels_base_link_map[vessel_name],
+                base_link_entity,
                 lin_vel);
             const auto angularVel =
                 _ecm.Component<gz::sim::components::WorldAngularVelocity>(
-                    m_vessels_base_link_map[vessel_name]);
+                    base_link_entity);
             *angularVel = gz::sim::components::WorldAngularVelocity(ang_vel);
         } else {
             m_logger->warn(

--- a/systems/physics_engine_interface/src/physics_interface_plugin.cpp
+++ b/systems/physics_engine_interface/src/physics_interface_plugin.cpp
@@ -198,8 +198,7 @@ void PhysicsInterfacePlugin::updateVesselState(
         const std::chrono::_V2::system_clock::time_point start_time =
             std::chrono::system_clock::now();
 
-        // Phase 1: read the state from the ECM (serialised, ECM not
-        // thread-safe).
+        // Phase 1: read the state from the ECM (serialised, ECM not thread-safe)
         VesselInformation vessel_info;
         {
             std::lock_guard<std::mutex> ecm_lock(m_ecm_mutex);
@@ -214,7 +213,7 @@ void PhysicsInterfacePlugin::updateVesselState(
             pose = pose_comp->Data();
 
             gz::sim::Link _link(base_link_entity);
-            // World frame, ENU.
+            // World frame, ENU
             auto lin_vel_opt = _link.WorldLinearVelocity(_ecm);
             auto ang_vel_opt = _link.WorldAngularVelocity(_ecm);
 
@@ -233,9 +232,8 @@ void PhysicsInterfacePlugin::updateVesselState(
             vessel_info.pose = pose;
         }
 
-        // Phase 2: compute the new state (runs in parallel, no ECM access).
-        update_opt =
-            interface->getNewState(vessel_entity, vessel_info, target_time);
+        // Phase 2: compute the new state (runs in parallel, no ECM access)
+        update_opt = interface->getNewState(vessel_entity, vessel_info, target_time);
 
         // Print physics engine response time if compiled in debug mode
         if (m_logger->level() < spdlog::level::info) {
@@ -247,7 +245,7 @@ void PhysicsInterfacePlugin::updateVesselState(
                     .count());
         }
 
-        // Phase 3: write the new state to the ECM (serialised).
+        // Phase 3: write the new state to the ECM (serialised)
         if (update_opt) {
             if (!vesselDomainTransition(
                     vessel_entity,

--- a/systems/physics_engine_interface/src/xdyn_websocket.cpp
+++ b/systems/physics_engine_interface/src/xdyn_websocket.cpp
@@ -209,15 +209,27 @@ bool XdynWebsocket::activateInterface(
             websocketpp::lib::placeholders::_2));
 
         int retry = 0;
-        while (m_status[_entity] != "opened" && retry < 3) {
+        const auto poll_interval = std::chrono::milliseconds(50);
+        const auto per_attempt_timeout = std::chrono::seconds(3);
+
+        auto is_opened = [&]() {
+            std::unique_lock<std::mutex> lock(m_variable_mutex);
+            return m_status[_entity] == "opened";
+        };
+
+        while (!is_opened() && retry < 3) {
             m_logger->info(
                 "XdynWebsocket::activateInterface: Starting connection: {}",
                 m_name_mapping[_entity]);
             m_client.connect(con);
-            std::this_thread::sleep_for(std::chrono::seconds(3));
+            auto attempt_start = std::chrono::steady_clock::now();
+            while (!is_opened() &&
+                std::chrono::steady_clock::now() - attempt_start < per_attempt_timeout) {
+                std::this_thread::sleep_for(poll_interval);
+            }
             retry += 1;
         }
-        if (retry > 2) {
+        if (!is_opened()) {
             m_logger->error(
                 "XdynWebsocket::activateInterface: Called for vessel entity {} but unable to connect.",
                 _entity);
@@ -406,9 +418,15 @@ bool XdynWebsocket::send(
     const gz::sim::Entity& _entity,
     const std::string& message)
 {
-    std::unique_lock<std::mutex> lock(m_variable_mutex);
-    // Guard to help with setup time
-    auto conn_ptr = m_connection_mapping[_entity];
+    Client::connection_ptr conn_ptr;
+    std::mutex* msg_mutex_ptr = nullptr;
+    std::condition_variable* msg_cv_ptr = nullptr;
+    {
+        std::unique_lock<std::mutex> lock(m_variable_mutex);
+        conn_ptr = m_connection_mapping[_entity];
+        msg_mutex_ptr = &m_msg_mutex[_entity];
+        msg_cv_ptr = &m_msg_cv[_entity];
+    }
     if (!conn_ptr) {
         m_logger->warn("Websocket connection not ready, skipping send.");
         return false;
@@ -425,17 +443,14 @@ bool XdynWebsocket::send(
             ec.message());
         return false;
     }
-    {
-        std::unique_lock<std::mutex> lock(m_msg_mutex[_entity]);
-        if (m_msg_cv[_entity].wait_for(
-                lock,
-                std::chrono::seconds(DEFAULT_WEBSOCKET_TIMEOUT)) ==
-            std::cv_status::timeout) {
-            m_logger->warn("XdynWebsocket::send: websocket timed out.");
-            return false;
-        } else {
-            return true;
-        }
+    std::unique_lock<std::mutex> msg_lock(*msg_mutex_ptr);
+    if (msg_cv_ptr->wait_for(
+            msg_lock,
+            std::chrono::seconds(DEFAULT_WEBSOCKET_TIMEOUT)) ==
+        std::cv_status::timeout) {
+        m_logger->warn("XdynWebsocket::send: websocket timed out.");
+        return false;
     }
+    return true;
 }
 }  // namespace lotusim::gazebo


### PR DESCRIPTION
The ECM is not thread-safe, and a scenario with enough models brought the server down with a double free inside the update loop. When checking this issue that IRL CROSSING had, I found that `activateInterface`'s connect loop blocked the main simulation thread for 3 seconds per vessel, whether the connection was already established or not. And  `XdynWebsocket::send()` held its lock for the entire blocking wait on a reply.

Fix

1. IRL CROSSING's fix
Reads and writes to the ECM now happen under a dedicated lock (`m_ecm_mutex`), while the physics step itself (`getNewState`) stays parallel between the read and write phases. The base link entity is also resolved once under the existing mapping lock, via `.find()` instead of `operator[]` from multiple threads.

2. Follow-up fixes found during testing
I made a stress test spawning 50 vessels to trigger the race IRL CROSSING described. I faced the same issue + 2 more issues severe enough that the stress test wasn't runnable without fixing them too:
- `activateInterface`'s connect loop blocked the main simulation thread for 3 sec per vessel, even if the connection opened within ms, because it unconditionally slept before rechecking status. With 50 vessels, this meant ~150s just to finish spawning, freezing the whole sim during that time.
- `XdynWebsocket::send()` held its lock for the entire blocking wait on a reply, not just the connection lookup, so every vessel's send queued behind every other vessel's. Confirmed with a wait-time log (5000ms → 10000ms → 15001ms for the 2nd, 3rd, 4th vessel).

This PR adds: short-interval checks in `activateInterface` instead of the blind 3 sec sleep, and a narrower lock in `send()` so each vessel waits on its own per-entity mutex/condition-variable instead of a single shared one.

Now, spawning 50 vessels takes a few seconds instead of ~150s, and vessel sends no longer serialize behind one another. The stress test runs for several minutes with no crashes or errors.