### PR TITLE
fix: find the versioned nixGLNvidia wrapper

### DIFF
--- a/scripts/gl-wrapper.sh
+++ b/scripts/gl-wrapper.sh
@@ -40,5 +40,20 @@ if [ -n "${LOTUSIM_GL_WRAPPER:-}" ]; then
 fi
 
 # nixGLIntel first: plain nixGL bundles the NVIDIA stack and is the wrong guess
-# on a hybrid machine.
-resolve nixGLIntel nixGL nixGLNvidia
+# on a hybrid machine. nixGL installs its NVIDIA wrapper under a name carrying
+# the driver version, so match that too — otherwise a machine whose Intel
+# wrapper cannot reach the GPU finds nothing, and every rendering sensor fails
+# to build its context.
+if resolve nixGLIntel nixGL nixGLNvidia; then
+  exit 0
+fi
+
+for dir in "$HOME/.nix-profile/bin" "/nix/var/nix/profiles/default/bin"; do
+  for candidate in "$dir"/nixGLNvidia-*; do
+    if [ -x "$candidate" ]; then
+      echo "$candidate"
+      exit 0
+    fi
+  done
+done
+exit 1


### PR DESCRIPTION
The logic is sound. In the original last line: `resolve nixGLIntel nixGL nixGLNvidia` -> with `set -e` active (line 13), if none of
those names resolved, the script would die with no fallback. This PR wraps that same call in `if resolve ...; then exit
0; fi`. A failure now falls back  into a for-loop. This matches known `nixGL` behavior: the NVIDIA wrapper gets installed under a versioned filename, unlike the stable `nixGLIntel`/`nixGL` names, so a plain `command -v nixGLNvidia` lookup can find nothing even when a working NVIDIA wrapper is present.

I couldn't reproduce the original bug directly on my machine. Since I have a plain `nixGL` binary that already resolves via the existing `resolve()` call, the new fallback path never triggers for me. 